### PR TITLE
docs: document optional metrics persistence (queue-metrics v2.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Deep queue monitoring for any Laravel queue driver. Not just Horizon.**
 
-Track every queue job with per-job CPU, memory, payload, exceptions, and retry chains — on `database`, `redis`, `sqs`, `beanstalkd`, or any driver that fires Laravel's queue events. No Horizon required.
+Track every queue job with per-job CPU, memory, payload, exceptions, and retry chains — on `database`, `redis`, `sqs`, `beanstalkd`, or any driver that fires Laravel's queue events. No Redis required. No Horizon required.
 
 ## Why?
 
@@ -59,35 +59,39 @@ That's it. The package automatically starts monitoring all queue jobs.
 
 ### Metrics Storage
 
-Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for CPU/memory instrumentation. Metrics data needs a fast storage backend — you have two options:
+Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU/memory instrumentation. By default, queue-metrics also persists aggregate data (worker heartbeats, throughput, baselines) to a storage backend. Queue Monitor only needs the per-job events — not the aggregate persistence.
 
-#### Redis (default, recommended)
+If you only use Queue Monitor (without [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale)), you can disable metrics persistence to avoid any storage backend requirement:
 
-Redis is used by default. No extra configuration needed if you already have a Redis connection.
+```env
+QUEUE_METRICS_PERSISTENCE=false
+```
+
+This gives you per-job CPU and memory tracking with zero additional infrastructure. No Redis, no extra tables.
+
+#### With persistence enabled (default)
+
+If you want the full metrics stack (Prometheus export, baselines, worker heartbeats) or use [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale), persistence must stay enabled. Two storage options:
+
+**Redis (recommended):**
 
 ```env
 QUEUE_METRICS_STORAGE=redis
 QUEUE_METRICS_CONNECTION=default
 ```
 
-This is the recommended driver for all production workloads. See the [laravel-queue-metrics docs](https://github.com/cboxdk/laravel-queue-metrics) for advanced Redis configuration.
-
-#### Database
-
-If you don't run Redis, metrics can be stored in your application database:
+**Database** (for low-scale workloads without Redis):
 
 ```env
 QUEUE_METRICS_STORAGE=database
 ```
-
-Publish and run the metrics storage migration:
 
 ```bash
 php artisan vendor:publish --tag="queue-metrics-migrations"
 php artisan migrate
 ```
 
-> **Performance note:** The database driver is designed for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. We recommend setting `QUEUE_METRICS_MAX_SAMPLES=500` to keep table sizes manageable. See the [laravel-queue-metrics docs](https://github.com/cboxdk/laravel-queue-metrics) for details.
+> **Performance note:** The database driver is for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. We recommend `QUEUE_METRICS_MAX_SAMPLES=500`. See the [laravel-queue-metrics docs](https://github.com/cboxdk/laravel-queue-metrics) for details.
 
 ### Optional: Publish views for customization
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,22 +39,30 @@ The package will create three tables:
 
 ### 4. Configure Metrics Storage
 
-Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU and memory instrumentation. Metrics data is stored separately from job records and needs a fast storage backend.
+Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU and memory instrumentation. By default, queue-metrics also persists aggregate data (worker heartbeats, throughput, baselines) to a storage backend.
 
-#### Redis (default)
+**Queue Monitor only needs the per-job events — not the aggregate persistence.** If you only use Queue Monitor (without [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale)), you can disable persistence entirely:
 
-If you already have a Redis connection, no configuration needed — this is the default.
+```env
+QUEUE_METRICS_PERSISTENCE=false
+```
+
+This gives you per-job CPU and memory tracking with zero additional infrastructure. No Redis, no extra database tables. Skip to step 5.
+
+#### With persistence enabled (default)
+
+If you want the full metrics stack (Prometheus export, baselines, worker heartbeats) or use [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale), persistence stays enabled. Choose a storage backend:
+
+**Redis (recommended):**
 
 ```env
 QUEUE_METRICS_STORAGE=redis
 QUEUE_METRICS_CONNECTION=default
 ```
 
-Redis is the recommended driver for all production workloads.
+No extra setup needed if you already have a Redis connection.
 
-#### Database
-
-If you don't run Redis, metrics can be stored in your application database:
+**Database** (for low-scale workloads without Redis):
 
 ```env
 QUEUE_METRICS_STORAGE=database
@@ -67,9 +75,7 @@ php artisan vendor:publish --tag="queue-metrics-migrations"
 php artisan migrate
 ```
 
-This creates 4 additional tables (`queue_metrics_keys`, `queue_metrics_hashes`, `queue_metrics_sets`, `queue_metrics_sorted_sets`) used for metrics storage.
-
-> **Performance note:** The database driver is designed for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. We recommend `QUEUE_METRICS_MAX_SAMPLES=500` to keep table sizes manageable.
+> **Performance note:** The database driver is for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. We recommend `QUEUE_METRICS_MAX_SAMPLES=500`.
 
 For full configuration options, see the [laravel-queue-metrics documentation](https://github.com/cboxdk/laravel-queue-metrics).
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -20,24 +20,13 @@ That's it! Jobs are now being monitored automatically.
 
 ### Metrics Storage
 
-Queue Monitor uses [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for CPU/memory instrumentation. By default, metrics are stored in **Redis**. If you don't have Redis, you can use the database driver:
+Queue Monitor uses [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for CPU/memory instrumentation. No extra infrastructure is required — disable metrics persistence if you don't have Redis:
 
 ```env
-# Default — uses Redis (recommended)
-QUEUE_METRICS_STORAGE=redis
-
-# Alternative — uses your application database
-QUEUE_METRICS_STORAGE=database
+QUEUE_METRICS_PERSISTENCE=false
 ```
 
-For the database driver, publish and run the metrics migration:
-
-```bash
-php artisan vendor:publish --tag="queue-metrics-migrations"
-php artisan migrate
-```
-
-> **Note:** The database driver is for low-scale workloads (< 10 workers). At higher scale, use Redis. See the [installation guide](installation) for details.
+You still get per-job CPU and memory tracking. If you want the full metrics stack (Prometheus, baselines, worker heartbeats) or use [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale), keep persistence enabled and configure a storage backend. See the [installation guide](installation) for details.
 
 ## View Your First Job
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -100,28 +100,27 @@ You can add custom middleware for authentication:
 
 ## Metrics Storage
 
-Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU and memory instrumentation. Metrics data is stored separately from job records.
+Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU and memory instrumentation. Queue-metrics also provides aggregate persistence (worker heartbeats, throughput, baselines) — but Queue Monitor doesn't need it.
 
-### Redis (default)
+### Disable persistence (simplest setup)
 
-Redis is the default and recommended storage driver. No extra configuration needed if you have a Redis connection:
-
-```env
-QUEUE_METRICS_STORAGE=redis
-QUEUE_METRICS_CONNECTION=default
-```
-
-### Database
-
-For applications without Redis, metrics can be stored in your application database:
+If you only use Queue Monitor (not [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale)), disable metrics persistence to skip any storage backend:
 
 ```env
-QUEUE_METRICS_STORAGE=database
+QUEUE_METRICS_PERSISTENCE=false
 ```
 
-Additional configuration in `config/queue-metrics.php`:
+Per-job CPU/memory still works — only aggregate persistence is skipped.
+
+### With persistence enabled (default)
+
+When persistence is on, configure a storage backend in `config/queue-metrics.php`:
 
 ```php
+'persistence' => [
+    'enabled' => env('QUEUE_METRICS_PERSISTENCE', true),
+],
+
 'storage' => [
     'driver' => env('QUEUE_METRICS_STORAGE', 'redis'),
     'connection' => env('QUEUE_METRICS_CONNECTION', 'default'),
@@ -131,7 +130,7 @@ Additional configuration in `config/queue-metrics.php`:
 ],
 ```
 
-> **Performance note:** The database driver is designed for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. Use Redis for moderate to high workloads.
+**Redis** is the recommended driver. **Database** is available for low-scale workloads (< 10 workers) without Redis — see the [installation guide](../getting-started/installation) for setup.
 
 For full metrics configuration options, see the [laravel-queue-metrics documentation](https://github.com/cboxdk/laravel-queue-metrics).
 

--- a/docs/reference/metrics-integration.md
+++ b/docs/reference/metrics-integration.md
@@ -199,12 +199,24 @@ foreach ($queueStats as $stat) {
 
 ## Configuration
 
-### Metrics Storage
+### Persistence
 
-Queue-metrics stores instrumentation data (CPU samples, memory samples, worker heartbeats) in a separate storage backend. This is independent of your queue driver.
+Queue-metrics has two layers: **instrumentation** (per-job CPU/memory events) and **persistence** (aggregate storage of workers, throughput, baselines).
+
+Queue Monitor only needs the instrumentation layer. If you don't use [queue-autoscale](https://github.com/cboxdk/laravel-queue-autoscale) or Prometheus export, you can disable persistence:
 
 ```php
 // config/queue-metrics.php
+'persistence' => [
+    'enabled' => env('QUEUE_METRICS_PERSISTENCE', true),
+],
+```
+
+With persistence off: per-job CPU/memory events still fire and Queue Monitor captures them. No storage backend required.
+
+### Storage Backend (when persistence is enabled)
+
+```php
 'storage' => [
     // 'redis' (default, recommended) or 'database'
     'driver' => env('QUEUE_METRICS_STORAGE', 'redis'),
@@ -215,18 +227,11 @@ Queue-metrics stores instrumentation data (CPU samples, memory samples, worker h
 ],
 ```
 
-**Redis** is the recommended driver for all production workloads. **Database** is available for teams without Redis infrastructure, but is only suitable for low-scale workloads (< 10 workers) due to write contention.
-
-For the database driver, publish and run the metrics storage migration:
-
-```bash
-php artisan vendor:publish --tag="queue-metrics-migrations"
-php artisan migrate
-```
+**Redis** is the recommended driver. **Database** is available for low-scale workloads (< 10 workers). See the [installation guide](../getting-started/installation) for setup.
 
 ### Metrics Collection
 
-Queue-metrics collects data automatically — no extra configuration needed beyond storage driver selection.
+Queue-metrics instruments jobs automatically — no configuration needed beyond persistence and storage settings.
 
 ### Integration Settings
 


### PR DESCRIPTION
## Summary

queue-metrics v2.6.0 added `QUEUE_METRICS_PERSISTENCE=false`. This updates all docs to explain the three setup tiers:

1. **No persistence** (`QUEUE_METRICS_PERSISTENCE=false`) — per-job CPU/memory, no storage backend needed
2. **Redis persistence** (default) — full metrics stack
3. **Database persistence** — for low-scale without Redis

Restored "No Redis required" claim in README — now truthful with persistence disabled.

Updated: README, installation, quickstart, configuration, metrics-integration.