### PR TITLE
feat: add resolve actions for stuck jobs on health page

### DIFF
--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -651,12 +651,28 @@
                                         <div class="text-[11px] text-gray-500 mt-0.5" x-text="health.checks[name].message"></div>
                                         <template x-if="name === 'stuck_jobs' && health.checks[name].details?.stuck_jobs?.length > 0">
                                             <div class="mt-2 space-y-1.5">
+                                                <div class="flex items-center justify-end gap-2 mb-1">
+                                                    <button @click="resolveAllStuckJobs('retry')" class="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-md hover:bg-amber-100 transition" title="Retry all stuck jobs">
+                                                        <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" /></svg>
+                                                        Retry All
+                                                    </button>
+                                                    <button @click="resolveAllStuckJobs('delete')" class="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 transition" title="Delete all stuck jobs">
+                                                        <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" /></svg>
+                                                        Clear All
+                                                    </button>
+                                                </div>
                                                 <template x-for="sj in health.checks[name].details.stuck_jobs" :key="sj.uuid">
                                                     <div class="flex items-center gap-2 text-[11px] bg-red-50 border border-red-100 rounded-lg px-3 py-1.5">
                                                         <span class="font-mono font-medium text-red-800 cursor-pointer hover:underline" x-text="shortClass(sj.job_class)" @click="openJobView(sj.uuid)"></span>
                                                         <span class="text-red-600" x-text="'-> ' + sj.queue"></span>
                                                         <span class="text-red-400" x-text="'on ' + sj.server"></span>
                                                         <span class="text-red-400 ml-auto" x-text="'since ' + formatTime(sj.stuck_since)"></span>
+                                                        <button @click.stop="resolveStuckJob(sj.uuid, 'retry')" class="p-1 text-amber-600 hover:text-amber-800 hover:bg-amber-100 rounded transition" title="Retry this job">
+                                                            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" /></svg>
+                                                        </button>
+                                                        <button @click.stop="resolveStuckJob(sj.uuid, 'delete')" class="p-1 text-red-600 hover:text-red-800 hover:bg-red-100 rounded transition" title="Delete this job">
+                                                            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" /></svg>
+                                                        </button>
                                                     </div>
                                                 </template>
                                             </div>
@@ -1564,6 +1580,28 @@
                         await fetch(`/${apiBase}/batch/replay`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' }, body: JSON.stringify({ uuids: this.selectedJobs }) });
                         this.selectedJobs = []; this.fetchJobs();
                     } catch (e) { this.error = 'Failed to replay jobs'; console.error('batchReplay error:', e); }
+                },
+
+                async resolveStuckJob(uuid, action) {
+                    if (!uuid) return;
+                    if (action === 'delete' && !confirm('Delete this stuck job? This cannot be undone.')) return;
+                    try {
+                        const apiBase = '{{ config("queue-monitor.api.prefix", "api/queue-monitor") }}';
+                        const res = await fetch(`/${apiBase}/stuck-jobs/resolve`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' }, body: JSON.stringify({ uuids: [uuid], action }) });
+                        if (!res.ok) throw new Error('Request failed');
+                        this.fetchHealth();
+                    } catch (e) { this.error = `Failed to ${action} stuck job`; console.error('resolveStuckJob error:', e); }
+                },
+
+                async resolveAllStuckJobs(action) {
+                    const label = action === 'delete' ? 'delete' : 'retry';
+                    if (!confirm(`${label.charAt(0).toUpperCase() + label.slice(1)} all stuck jobs?`)) return;
+                    try {
+                        const apiBase = '{{ config("queue-monitor.api.prefix", "api/queue-monitor") }}';
+                        const res = await fetch(`/${apiBase}/stuck-jobs/resolve-all`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' }, body: JSON.stringify({ action }) });
+                        if (!res.ok) throw new Error('Request failed');
+                        this.fetchHealth();
+                    } catch (e) { this.error = `Failed to ${label} stuck jobs`; console.error('resolveAllStuckJobs error:', e); }
                 },
 
                 async batchDelete() {

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMonitor\Http\Controllers\JobMonitorController;
 use Cbox\LaravelQueueMonitor\Http\Controllers\JobReplayController;
 use Cbox\LaravelQueueMonitor\Http\Controllers\PruneController;
 use Cbox\LaravelQueueMonitor\Http\Controllers\StatisticsController;
+use Cbox\LaravelQueueMonitor\Http\Controllers\StuckJobController;
 use Cbox\LaravelQueueMonitor\Http\Middleware\EnsureQueueMonitorEnabled;
 use Illuminate\Support\Facades\Route;
 
@@ -54,6 +55,10 @@ Route::prefix(config('queue-monitor.api.prefix', 'api/queue-monitor'))
         // Batch Operations
         Route::post('/batch/replay', [BatchOperationsController::class, 'batchReplay'])->name('batch.replay');
         Route::post('/batch/delete', [BatchOperationsController::class, 'batchDelete'])->name('batch.delete');
+
+        // Stuck Jobs
+        Route::post('/stuck-jobs/resolve', [StuckJobController::class, 'resolve'])->name('stuck-jobs.resolve');
+        Route::post('/stuck-jobs/resolve-all', [StuckJobController::class, 'resolveAll'])->name('stuck-jobs.resolve-all');
 
         // Health & Monitoring
         Route::get('/health', [HealthCheckController::class, 'index'])->name('health');

--- a/src/Actions/ResolveStuckJobAction.php
+++ b/src/Actions/ResolveStuckJobAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Actions;
+
+use Cbox\LaravelQueueMonitor\Actions\Replay\ReplayJobAction;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Exceptions\JobNotFoundException;
+use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
+
+final readonly class ResolveStuckJobAction
+{
+    public function __construct(
+        private JobMonitorRepositoryContract $repository,
+        private ReplayJobAction $replayAction,
+    ) {}
+
+    /**
+     * @return array{resolved: int, replayed: int, errors: list<string>}
+     */
+    public function execute(array $uuids, string $action): array
+    {
+        $resolved = 0;
+        $replayed = 0;
+        $errors = [];
+
+        foreach ($uuids as $uuid) {
+            $job = $this->repository->findByUuid($uuid);
+
+            if ($job === null) {
+                $errors[] = "Job {$uuid} not found";
+                continue;
+            }
+
+            if ($job->status !== JobStatus::PROCESSING) {
+                $errors[] = "Job {$uuid} is not stuck (status: {$job->status->value})";
+                continue;
+            }
+
+            if ($action === 'delete') {
+                $this->repository->delete($uuid);
+                $resolved++;
+            } elseif ($action === 'retry') {
+                $this->repository->update($uuid, [
+                    'status' => JobStatus::TIMEOUT,
+                    'finished_at' => now(),
+                ]);
+                $resolved++;
+
+                try {
+                    $this->replayAction->execute($uuid);
+                    $replayed++;
+                } catch (\RuntimeException $e) {
+                    $errors[] = "Job {$uuid} marked as timeout but replay failed: {$e->getMessage()}";
+                }
+            }
+        }
+
+        return [
+            'resolved' => $resolved,
+            'replayed' => $replayed,
+            'errors' => $errors,
+        ];
+    }
+}

--- a/src/Actions/ResolveStuckJobAction.php
+++ b/src/Actions/ResolveStuckJobAction.php
@@ -16,6 +16,7 @@ final readonly class ResolveStuckJobAction
     ) {}
 
     /**
+     * @param  list<string>  $uuids
      * @return array{resolved: int, replayed: int, errors: list<string>}
      */
     public function execute(array $uuids, string $action): array

--- a/src/Actions/ResolveStuckJobAction.php
+++ b/src/Actions/ResolveStuckJobAction.php
@@ -6,7 +6,6 @@ namespace Cbox\LaravelQueueMonitor\Actions;
 
 use Cbox\LaravelQueueMonitor\Actions\Replay\ReplayJobAction;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
-use Cbox\LaravelQueueMonitor\Exceptions\JobNotFoundException;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
 
 final readonly class ResolveStuckJobAction
@@ -30,11 +29,13 @@ final readonly class ResolveStuckJobAction
 
             if ($job === null) {
                 $errors[] = "Job {$uuid} not found";
+
                 continue;
             }
 
             if ($job->status !== JobStatus::PROCESSING) {
                 $errors[] = "Job {$uuid} is not stuck (status: {$job->status->value})";
+
                 continue;
             }
 

--- a/src/Http/Controllers/StuckJobController.php
+++ b/src/Http/Controllers/StuckJobController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Http\Controllers;
+
+use Cbox\LaravelQueueMonitor\Actions\ResolveStuckJobAction;
+use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class StuckJobController extends Controller
+{
+    public function __construct(
+        private readonly ResolveStuckJobAction $resolveAction,
+    ) {}
+
+    public function resolve(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'action' => 'required|in:delete,retry',
+            'uuids' => 'required|array|min:1',
+            'uuids.*' => 'required|string',
+        ]);
+
+        $result = $this->resolveAction->execute($validated['uuids'], $validated['action']);
+
+        return response()->json([
+            'message' => match ($validated['action']) {
+                'delete' => "{$result['resolved']} stuck job(s) deleted",
+                'retry' => "{$result['resolved']} stuck job(s) resolved, {$result['replayed']} retried",
+            },
+            ...$result,
+        ]);
+    }
+
+    public function resolveAll(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'action' => 'required|in:delete,retry',
+        ]);
+
+        $stuckJobs = QueryBuilderHelper::stuck(30)->pluck('uuid')->toArray();
+
+        if (empty($stuckJobs)) {
+            return response()->json(['message' => 'No stuck jobs found', 'resolved' => 0, 'replayed' => 0, 'errors' => []]);
+        }
+
+        $result = $this->resolveAction->execute($stuckJobs, $validated['action']);
+
+        return response()->json([
+            'message' => match ($validated['action']) {
+                'delete' => "{$result['resolved']} stuck job(s) deleted",
+                'retry' => "{$result['resolved']} stuck job(s) resolved, {$result['replayed']} retried",
+            },
+            ...$result,
+        ]);
+    }
+}

--- a/src/Http/Controllers/StuckJobController.php
+++ b/src/Http/Controllers/StuckJobController.php
@@ -24,10 +24,12 @@ class StuckJobController extends Controller
             'uuids.*' => 'required|string',
         ]);
 
-        $result = $this->resolveAction->execute($validated['uuids'], $validated['action']);
-
+        /** @var list<string> $uuids */
+        $uuids = $validated['uuids'];
         /** @var string $action */
         $action = $validated['action'];
+
+        $result = $this->resolveAction->execute($uuids, $action);
 
         return response()->json([
             'message' => match ($action) {
@@ -45,16 +47,17 @@ class StuckJobController extends Controller
             'action' => 'required|in:delete,retry',
         ]);
 
+        /** @var list<string> $stuckJobs */
         $stuckJobs = QueryBuilderHelper::stuck(30)->pluck('uuid')->toArray();
 
         if (empty($stuckJobs)) {
             return response()->json(['message' => 'No stuck jobs found', 'resolved' => 0, 'replayed' => 0, 'errors' => []]);
         }
 
-        $result = $this->resolveAction->execute($stuckJobs, $validated['action']);
-
         /** @var string $action */
         $action = $validated['action'];
+
+        $result = $this->resolveAction->execute($stuckJobs, $action);
 
         return response()->json([
             'message' => match ($action) {

--- a/src/Http/Controllers/StuckJobController.php
+++ b/src/Http/Controllers/StuckJobController.php
@@ -26,10 +26,14 @@ class StuckJobController extends Controller
 
         $result = $this->resolveAction->execute($validated['uuids'], $validated['action']);
 
+        /** @var string $action */
+        $action = $validated['action'];
+
         return response()->json([
-            'message' => match ($validated['action']) {
+            'message' => match ($action) {
                 'delete' => "{$result['resolved']} stuck job(s) deleted",
                 'retry' => "{$result['resolved']} stuck job(s) resolved, {$result['replayed']} retried",
+                default => "{$result['resolved']} stuck job(s) resolved",
             },
             ...$result,
         ]);
@@ -49,10 +53,14 @@ class StuckJobController extends Controller
 
         $result = $this->resolveAction->execute($stuckJobs, $validated['action']);
 
+        /** @var string $action */
+        $action = $validated['action'];
+
         return response()->json([
-            'message' => match ($validated['action']) {
+            'message' => match ($action) {
                 'delete' => "{$result['resolved']} stuck job(s) deleted",
                 'retry' => "{$result['resolved']} stuck job(s) resolved, {$result['replayed']} retried",
+                default => "{$result['resolved']} stuck job(s) resolved",
             },
             ...$result,
         ]);


### PR DESCRIPTION
## Summary

Stuck jobs (status `PROCESSING` for 30+ minutes) persisted indefinitely in the health check and could only be cleared via direct database access. This was poor UX — users had no way to resolve them from the dashboard.

This PR adds delete and retry actions for stuck jobs directly on the health page:

- **Per-job actions**: each stuck job row now has retry (↻) and delete (🗑) icon buttons
- **Bulk actions**: "Retry All" and "Clear All" buttons above the stuck jobs list
- **Retry flow**: marks the job as `TIMEOUT`, then re-dispatches it via the existing `ReplayJobAction`
- **Delete flow**: removes the job record entirely

Health data refreshes automatically after any action, so the health score updates immediately.

### New files
- `src/Actions/ResolveStuckJobAction.php` — handles both delete and retry for one or more stuck jobs
- `src/Http/Controllers/StuckJobController.php` — API endpoints for resolve and resolve-all

### Modified files
- `routes/api.php` — two new routes: `POST /stuck-jobs/resolve` and `POST /stuck-jobs/resolve-all`
- `resources/views/web/dashboard.blade.php` — action buttons in stuck jobs UI + Alpine.js handler functions

## Test plan
- [ ] Verify stuck jobs appear on health page with retry and delete buttons
- [ ] Click delete on a single stuck job — confirm it disappears and health score updates
- [ ] Click retry on a single stuck job — confirm it gets re-dispatched and removed from stuck list
- [ ] Use "Clear All" to bulk-delete all stuck jobs
- [ ] Use "Retry All" to bulk-retry all stuck jobs
- [ ] Verify confirmation dialogs appear for destructive actions
- [ ] Verify non-stuck (non-PROCESSING) jobs cannot be resolved via these endpoints