### PR TITLE
fix: stat cards show correct totals and auto-refresh on autoscale tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
+## v1.7.2 - 2026-04-30
+
+### Fixes
+
+- **Autoscale stat cards wrong total**: `Total Decisions` now only counts actionable events (scale_up, scale_down, sla_breach, sla_recovered, sla_breach_predicted) instead of all events including hold/null decisions.
+- **Autoscale tab not auto-refreshing**: Include the autoscale tab in the main auto-refresh loop so stat cards update automatically.
+
 ## v1.7.1 - 2026-04-30
 
 ### Fixes

--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -1971,6 +1971,7 @@
                         if (this.activeTab === 'overview') this.fetchOverview();
                         else if (this.activeTab === 'jobs') this.fetchJobs();
                         else if (this.activeTab === 'health') this.fetchHealth();
+                        else if (this.activeTab === 'autoscale') this.fetchAutoscale();
                     }, {{ config('queue-monitor.ui.refresh_interval', 3000) }});
                 },
 

--- a/src/Services/InfrastructureService.php
+++ b/src/Services/InfrastructureService.php
@@ -341,7 +341,9 @@ final class InfrastructureService
                     ->all();
 
                 // Summary: aggregate counts (no full table load)
+                $trackedActions = ['scale_up', 'scale_down', 'sla_breach', 'sla_recovered', 'sla_breach_predicted'];
                 $summaryCounts = ScalingEvent::where('created_at', '>=', now()->subHour())
+                    ->whereIn('action', $trackedActions)
                     ->selectRaw('action, COUNT(*) as cnt')
                     ->groupBy('action')
                     ->pluck('cnt', 'action')


### PR DESCRIPTION
## Summary

- **Total Decisions** now only counts actionable scaling events (`scale_up`, `scale_down`, `sla_breach`, `sla_recovered`, `sla_breach_predicted`) — previously included `hold`/`null` decisions, making the total mismatch the breakdown cards
- Autoscale tab now auto-refreshes via the main refresh loop instead of requiring manual toggle

## Test plan

- [x] Existing tests pass (4 tests, 12 assertions)
- [ ] Verify stat cards show consistent totals on a live dashboard
- [ ] Confirm autoscale tab refreshes automatically when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)