### PR TITLE
Fix dashboard refresh state

### DIFF
--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -1864,6 +1864,8 @@
                 // Auto-refresh
                 refreshInterval: null,
                 isLive: true,
+                inFlight: { overview: false, jobs: false, analytics: false, health: false, infrastructure: false, autoscale: false, detail: false, drillDown: false },
+                pendingRefresh: { overview: false, jobs: false, analytics: false, health: false, infrastructure: false, autoscale: false, detail: false, drillDown: false },
                 loading: { overview: true, jobs: false, analytics: false, health: false, infrastructure: false, autoscale: false, detail: false },
                 error: null,
                 retryCount: 0,
@@ -1945,7 +1947,7 @@
                             // Restore filters from URL on back/forward
                             this.filters = { search: '', statuses: [], queue: '', dateFrom: '', dateTo: '', showAdvanced: false, jobClass: '', server: '', minAttempts: '', minDuration: '' };
                             this.restoreFiltersFromUrl();
-                            if (this.activeTab === 'jobs') this.fetchJobs();
+                            this.refreshCurrentView();
                         }
                     });
 
@@ -1966,16 +1968,58 @@
                 startAutoRefresh() {
                     if (this.refreshInterval) clearInterval(this.refreshInterval);
                     this.refreshInterval = setInterval(() => {
-                        if (!this.isLive || this.jobView) return;
-                        if (this.drillDown) { this.refreshDrillDown(); return; }
-                        if (this.activeTab === 'overview') this.fetchOverview();
-                        else if (this.activeTab === 'jobs') this.fetchJobs();
-                        else if (this.activeTab === 'health') this.fetchHealth();
-                        else if (this.activeTab === 'autoscale') this.fetchAutoscale();
+                        if (!this.isLive) return;
+                        this.refreshCurrentView();
                     }, {{ config('queue-monitor.ui.refresh_interval', 3000) }});
                 },
 
-                toggleLive() { this.isLive = !this.isLive; },
+                toggleLive() {
+                    this.isLive = !this.isLive;
+                    if (this.isLive) this.refreshCurrentView();
+                },
+
+                refreshCurrentView() {
+                    if (this.jobView) { this.fetchJobDetail(this.jobView); return; }
+                    if (this.drillDown) { this.refreshDrillDown(); return; }
+                    if (this.activeTab === 'overview') { this.fetchOverview(); this.fetchHealth(); }
+                    else if (this.activeTab === 'jobs') this.fetchJobs();
+                    else if (this.activeTab === 'analytics') this.fetchAnalytics();
+                    else if (this.activeTab === 'health') this.fetchHealth();
+                    else if (this.activeTab === 'infrastructure') this.fetchInfrastructure();
+                    else if (this.activeTab === 'autoscale' && !this.autoscaleAutoRefresh) this.fetchAutoscale();
+                },
+
+                async runLatest(scope, callback) {
+                    if (this.inFlight[scope]) {
+                        this.pendingRefresh[scope] = true;
+                        return;
+                    }
+
+                    this.inFlight[scope] = true;
+                    this.pendingRefresh[scope] = false;
+
+                    try {
+                        await callback();
+                    } finally {
+                        this.inFlight[scope] = false;
+
+                        if (this.pendingRefresh[scope]) {
+                            this.pendingRefresh[scope] = false;
+                            this.refreshScope(scope);
+                        }
+                    }
+                },
+
+                refreshScope(scope) {
+                    if (scope === 'overview') this.fetchOverview();
+                    else if (scope === 'jobs') this.fetchJobs();
+                    else if (scope === 'analytics') this.fetchAnalytics();
+                    else if (scope === 'health') this.fetchHealth();
+                    else if (scope === 'infrastructure') this.fetchInfrastructure();
+                    else if (scope === 'autoscale') this.fetchAutoscale();
+                    else if (scope === 'detail' && this.jobView) this.fetchJobDetail(this.jobView);
+                    else if (scope === 'drillDown') this.refreshDrillDown();
+                },
 
                 // ========== NAVIGATION ==========
 
@@ -2055,24 +2099,27 @@
                 },
 
                 async fetchOverview() {
-                    try {
+                    return this.runLatest('overview', async () => {
+                        try {
                         const data = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.metrics") }}');
                         this.overview.stats = data.stats || {};
                         this.overview.queues = data.queues || [];
                         this.overview.alerts = data.alerts || {};
                         this.overview.recentJobs = data.recent_jobs || [];
                         this.overview.charts = data.charts || {};
-                        const queueNames = (data.queues || []).map(q => q.queue);
-                        if (queueNames.length > this.availableQueues.length) this.availableQueues = queueNames;
+                        const queueNames = [...new Set((data.queues || []).map(q => q.queue).filter(Boolean))].sort();
+                        if (this.availableQueues.length === 0 && queueNames.length > 0) this.availableQueues = queueNames;
                         if (data.horizon_available !== undefined) this.horizonAvailable = data.horizon_available;
                         this.loading.overview = false;
                         this.$nextTick(() => { this.initThroughputChart(); this.updateThroughputChart(data.charts?.throughput); });
-                    } catch (e) { this.loading.overview = false; console.error('fetchOverview error:', e); }
+                        } catch (e) { this.loading.overview = false; console.error('fetchOverview error:', e); }
+                    });
                 },
 
                 async fetchJobs() {
-                    if (this.jobs.data.length === 0) this.loading.jobs = true;
-                    try {
+                    return this.runLatest('jobs', async () => {
+                        if (this.jobs.data.length === 0) this.loading.jobs = true;
+                        try {
                         const params = new URLSearchParams();
                         if (this.filters.search) params.append('search', this.filters.search);
                         this.filters.statuses.forEach(s => params.append('statuses[]', s));
@@ -2092,48 +2139,60 @@
                         this.jobs.meta = data.meta || {};
                         this.pagination.total = data.meta?.total || 0;
                         const metaQueues = data.meta?.available_queues || [];
-                        if (metaQueues.length > 0) this.availableQueues = metaQueues;
+                        if (Array.isArray(metaQueues)) this.availableQueues = metaQueues;
                         else if (this.availableQueues.length === 0 && this.jobs.data.length > 0) this.availableQueues = [...new Set(this.jobs.data.map(j => j.queue).filter(Boolean))].sort();
-                    } catch (e) { console.error('fetchJobs error:', e); } finally { this.loading.jobs = false; }
+                        } catch (e) { console.error('fetchJobs error:', e); } finally { this.loading.jobs = false; }
+                    });
                 },
 
                 async fetchJobDetail(uuid) {
-                    this.loading.detail = true;
-                    try {
+                    return this.runLatest('detail', async () => {
+                        this.loading.detail = true;
+                        try {
                         const url = '{{ route("queue-monitor.dashboard.job.detail", ["uuid" => "_UUID_"]) }}'.replace('_UUID_', uuid);
                         const data = await this.fetchWithRetry(url);
+                        if (this.jobView !== uuid) return;
                         this.jobDetail = data;
-                    } catch (e) { console.error('fetchJobDetail error:', e); } finally { this.loading.detail = false; }
+                        } catch (e) { console.error('fetchJobDetail error:', e); } finally { this.loading.detail = false; }
+                    });
                 },
 
                 async fetchAnalytics() {
-                    if (Object.keys(this.analytics).length === 0) this.loading.analytics = true;
-                    try {
+                    return this.runLatest('analytics', async () => {
+                        if (Object.keys(this.analytics).length === 0) this.loading.analytics = true;
+                        try {
                         const data = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.analytics") }}');
                         this.analytics = data;
                         this.$nextTick(() => { this.initDistributionChart(); this.updateDistributionChart(data.job_classes); });
-                    } catch (e) { console.error('fetchAnalytics error:', e); } finally { this.loading.analytics = false; }
+                        } catch (e) { console.error('fetchAnalytics error:', e); } finally { this.loading.analytics = false; }
+                    });
                 },
 
                 async fetchHealth() {
-                    if (Object.keys(this.health).length === 0) this.loading.health = true;
-                    try { this.health = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.health") }}'); } catch (e) { console.error('fetchHealth error:', e); } finally { this.loading.health = false; }
+                    return this.runLatest('health', async () => {
+                        if (Object.keys(this.health).length === 0) this.loading.health = true;
+                        try { this.health = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.health") }}'); } catch (e) { console.error('fetchHealth error:', e); } finally { this.loading.health = false; }
+                    });
                 },
 
                 async fetchInfrastructure() {
-                    if (Object.keys(this.infrastructure).length === 0) this.loading.infrastructure = true;
-                    try { this.infrastructure = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.infrastructure") }}'); } catch (e) { console.error('fetchInfrastructure error:', e); } finally { this.loading.infrastructure = false; }
+                    return this.runLatest('infrastructure', async () => {
+                        if (Object.keys(this.infrastructure).length === 0) this.loading.infrastructure = true;
+                        try { this.infrastructure = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.infrastructure") }}'); } catch (e) { console.error('fetchInfrastructure error:', e); } finally { this.loading.infrastructure = false; }
+                    });
                 },
 
                 async fetchAutoscale() {
-                    if (Object.keys(this.autoscale).length === 0) this.loading.autoscale = true;
-                    try { this.autoscale = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.autoscale") }}'); } catch (e) { console.error('fetchAutoscale error:', e); } finally { this.loading.autoscale = false; }
+                    return this.runLatest('autoscale', async () => {
+                        if (Object.keys(this.autoscale).length === 0) this.loading.autoscale = true;
+                        try { this.autoscale = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.autoscale") }}'); } catch (e) { console.error('fetchAutoscale error:', e); } finally { this.loading.autoscale = false; }
+                    });
                 },
 
                 startAutoscaleAutoRefresh() {
                     this.stopAutoscaleAutoRefresh();
                     this.autoscaleRefreshInterval = setInterval(() => {
-                        if (this.activeTab === 'autoscale') this.fetchAutoscale();
+                        if (this.isLive && this.activeTab === 'autoscale') this.fetchAutoscale();
                     }, 5000);
                 },
 
@@ -2234,13 +2293,15 @@
 
                 async refreshDrillDown() {
                     if (!this.drillDown) return;
-                    const { type, value } = this.drillDown;
-                    try {
+                    return this.runLatest('drillDown', async () => {
+                        const { type, value } = this.drillDown;
+                        try {
                         const url = `{{ route('queue-monitor.dashboard.drill-down') }}?type=${type}&value=${encodeURIComponent(value)}`;
                         const data = await this.fetchWithRetry(url);
                         this.drillDownData = data;
                         this.updateDrillDownChart(data?.throughput);
-                    } catch (e) { console.error('refreshDrillDown error:', e); }
+                        } catch (e) { console.error('refreshDrillDown error:', e); }
+                    });
                 },
 
                 drillDownToJobs(type, value) {

--- a/src/DataTransferObjects/JobFilterData.php
+++ b/src/DataTransferObjects/JobFilterData.php
@@ -72,12 +72,7 @@ final readonly class JobFilterData
     public static function fromRequest(array $data): self
     {
         return new self(
-            statuses: isset($data['statuses']) && is_array($data['statuses'])
-                ? array_map(
-                    fn (mixed $status): JobStatus => JobStatus::from(is_string($status) ? $status : (is_scalar($status) ? (string) $status : '')),
-                    $data['statuses']
-                )
-                : null,
+            statuses: self::parseStatuses($data['statuses'] ?? null),
             queues: isset($data['queues']) && is_array($data['queues'])
                 ? array_values(array_map(fn (mixed $v): string => is_string($v) ? $v : (is_scalar($v) ? (string) $v : ''), $data['queues']))
                 : null,
@@ -93,18 +88,18 @@ final readonly class JobFilterData
             tags: isset($data['tags']) && is_array($data['tags'])
                 ? array_values(array_map(fn (mixed $v): string => is_string($v) ? $v : (is_scalar($v) ? (string) $v : ''), $data['tags']))
                 : null,
-            queuedAfter: isset($data['queued_after']) && (is_string($data['queued_after']) || is_numeric($data['queued_after'])) ? Carbon::parse($data['queued_after']) : null,
-            queuedBefore: isset($data['queued_before']) && (is_string($data['queued_before']) || is_numeric($data['queued_before'])) ? Carbon::parse($data['queued_before']) : null,
-            startedAfter: isset($data['started_after']) && (is_string($data['started_after']) || is_numeric($data['started_after'])) ? Carbon::parse($data['started_after']) : null,
-            startedBefore: isset($data['started_before']) && (is_string($data['started_before']) || is_numeric($data['started_before'])) ? Carbon::parse($data['started_before']) : null,
-            completedAfter: isset($data['completed_after']) && (is_string($data['completed_after']) || is_numeric($data['completed_after'])) ? Carbon::parse($data['completed_after']) : null,
-            completedBefore: isset($data['completed_before']) && (is_string($data['completed_before']) || is_numeric($data['completed_before'])) ? Carbon::parse($data['completed_before']) : null,
+            queuedAfter: self::parseDate($data['queued_after'] ?? null),
+            queuedBefore: self::parseDate($data['queued_before'] ?? null),
+            startedAfter: self::parseDate($data['started_after'] ?? null),
+            startedBefore: self::parseDate($data['started_before'] ?? null),
+            completedAfter: self::parseDate($data['completed_after'] ?? null),
+            completedBefore: self::parseDate($data['completed_before'] ?? null),
             minDurationMs: isset($data['min_duration_ms']) && is_numeric($data['min_duration_ms']) ? (int) $data['min_duration_ms'] : null,
             maxDurationMs: isset($data['max_duration_ms']) && is_numeric($data['max_duration_ms']) ? (int) $data['max_duration_ms'] : null,
             minAttempts: isset($data['min_attempts']) && is_numeric($data['min_attempts']) ? (int) $data['min_attempts'] : null,
             search: isset($data['search']) && is_scalar($data['search']) ? (string) $data['search'] : null,
-            limit: isset($data['limit']) && is_numeric($data['limit']) ? min((int) $data['limit'], 1000) : 50,
-            offset: isset($data['offset']) && is_numeric($data['offset']) ? (int) $data['offset'] : 0,
+            limit: isset($data['limit']) && is_numeric($data['limit']) ? max(1, min((int) $data['limit'], 1000)) : 50,
+            offset: isset($data['offset']) && is_numeric($data['offset']) ? max(0, (int) $data['offset']) : 0,
             sortBy: self::validateSortColumn($data['sort_by'] ?? null),
             sortDirection: self::validateSortDirection($data['sort_direction'] ?? null),
         );
@@ -171,6 +166,14 @@ final readonly class JobFilterData
     }
 
     /**
+     * @return 'asc'|'desc'
+     */
+    public function sortDirectionForQuery(): string
+    {
+        return $this->sortDirection === 'asc' ? 'asc' : 'desc';
+    }
+
+    /**
      * Validate and return sort column
      */
     private static function validateSortColumn(mixed $column): string
@@ -196,5 +199,42 @@ final readonly class JobFilterData
         $direction = strtolower((string) $direction);
 
         return in_array($direction, ['asc', 'desc'], true) ? $direction : 'desc';
+    }
+
+    /**
+     * @return array<JobStatus>|null
+     */
+    private static function parseStatuses(mixed $statuses): ?array
+    {
+        if (! is_array($statuses)) {
+            return null;
+        }
+
+        $parsed = [];
+        foreach ($statuses as $status) {
+            if (! is_scalar($status)) {
+                continue;
+            }
+
+            $enum = JobStatus::tryFrom((string) $status);
+            if ($enum !== null) {
+                $parsed[] = $enum;
+            }
+        }
+
+        return $parsed !== [] ? $parsed : null;
+    }
+
+    private static function parseDate(mixed $value): ?Carbon
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/src/Http/Controllers/DashboardDrillDownController.php
+++ b/src/Http/Controllers/DashboardDrillDownController.php
@@ -7,6 +7,7 @@ namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentStatisticsRepository;
+use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -22,6 +23,7 @@ class DashboardDrillDownController extends Controller
 {
     public function __construct(
         private readonly StatisticsRepositoryContract $statsRepository,
+        private readonly DashboardCacheService $dashboardCache,
     ) {}
 
     /**
@@ -41,137 +43,133 @@ class DashboardDrillDownController extends Controller
         $type = $validated['type'];
         /** @var string $value */
         $value = $validated['value'];
-        // Cache drill-down for 30s to prevent expensive repeated queries
-        $cacheKey = 'queue_monitor:drill_down:'.md5($type.':'.$value);
-        $cached = cache()->get($cacheKey);
-        if ($cached !== null) {
-            return response()->json($cached);
-        }
+        $cacheKey = 'drill_down_'.md5($type.':'.$value);
 
-        // Map type to database column
-        $column = match ($type) {
-            'queue' => 'queue',
-            'server' => 'server_name',
-            'job_class' => 'job_class',
-            default => 'queue',
-        };
+        $result = $this->dashboardCache->remember($cacheKey, function () use ($type, $value): array {
 
-        /** @var string $prefix */
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
-        $table = $prefix.'jobs';
+            // Map type to database column
+            $column = match ($type) {
+                'queue' => 'queue',
+                'server' => 'server_name',
+                'job_class' => 'job_class',
+                default => 'queue',
+            };
 
-        // Stats
-        $completedValue = JobStatus::COMPLETED->value;
-        $failedValue = JobStatus::FAILED->value;
-        $timeoutValue = JobStatus::TIMEOUT->value;
+            /** @var string $prefix */
+            $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
+            $table = $prefix.'jobs';
 
-        $statsRow = DB::table($table)
-            ->selectRaw('COUNT(*) as total')
-            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as completed', [$completedValue])
-            ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [$failedValue, $timeoutValue])
-            ->selectRaw('AVG(CASE WHEN duration_ms IS NOT NULL THEN duration_ms END) as avg_duration_ms')
-            ->selectRaw('MAX(duration_ms) as max_duration_ms')
-            ->selectRaw('MIN(CASE WHEN duration_ms IS NOT NULL THEN duration_ms END) as min_duration_ms')
-            ->selectRaw('AVG(CASE WHEN memory_peak_mb IS NOT NULL THEN memory_peak_mb END) as avg_memory_mb')
-            ->where($column, $value)
-            ->first();
+            // Stats
+            $completedValue = JobStatus::COMPLETED->value;
+            $failedValue = JobStatus::FAILED->value;
+            $timeoutValue = JobStatus::TIMEOUT->value;
 
-        $total = $statsRow ? (int) $statsRow->total : 0;
-        $completed = $statsRow ? (int) $statsRow->completed : 0;
-        $failed = $statsRow ? (int) $statsRow->failed : 0;
-        $finished = $completed + $failed;
+            $statsRow = DB::table($table)
+                ->selectRaw('COUNT(*) as total')
+                ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as completed', [$completedValue])
+                ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [$failedValue, $timeoutValue])
+                ->selectRaw('AVG(CASE WHEN duration_ms IS NOT NULL THEN duration_ms END) as avg_duration_ms')
+                ->selectRaw('MAX(duration_ms) as max_duration_ms')
+                ->selectRaw('MIN(CASE WHEN duration_ms IS NOT NULL THEN duration_ms END) as min_duration_ms')
+                ->selectRaw('AVG(CASE WHEN memory_peak_mb IS NOT NULL THEN memory_peak_mb END) as avg_memory_mb')
+                ->where($column, $value)
+                ->first();
 
-        // Percentiles via sampled duration values (bounded to 1000 rows for memory safety)
-        $durations = DB::table($table)
-            ->where($column, $value)
-            ->whereNotNull('duration_ms')
-            ->orderBy('duration_ms')
-            ->limit(1000)
-            ->pluck('duration_ms')
-            ->map(fn (mixed $v): int => is_numeric($v) ? (int) $v : 0)
-            ->values()
-            ->all();
+            $total = $statsRow ? (int) $statsRow->total : 0;
+            $completed = $statsRow ? (int) $statsRow->completed : 0;
+            $failed = $statsRow ? (int) $statsRow->failed : 0;
+            $finished = $completed + $failed;
 
-        $p50 = $this->percentile($durations, 50);
-        $p95 = $this->percentile($durations, 95);
-        $p99 = $this->percentile($durations, 99);
+            // Percentiles via sampled duration values (bounded to 1000 rows for memory safety)
+            $durations = DB::table($table)
+                ->where($column, $value)
+                ->whereNotNull('duration_ms')
+                ->orderBy('duration_ms')
+                ->limit(1000)
+                ->pluck('duration_ms')
+                ->map(fn (mixed $v): int => is_numeric($v) ? (int) $v : 0)
+                ->values()
+                ->all();
 
-        $stats = [
-            'total' => $total,
-            'completed' => $completed,
-            'failed' => $failed,
-            'success_rate' => $finished > 0 ? round(($completed / $finished) * 100, 2) : 0,
-            'avg_duration_ms' => $statsRow && $statsRow->avg_duration_ms !== null ? round((float) $statsRow->avg_duration_ms, 2) : null,
-            'max_duration_ms' => $statsRow && $statsRow->max_duration_ms !== null ? (int) $statsRow->max_duration_ms : null,
-            'min_duration_ms' => $statsRow && $statsRow->min_duration_ms !== null ? (int) $statsRow->min_duration_ms : null,
-            'avg_memory_mb' => $statsRow && $statsRow->avg_memory_mb !== null ? round((float) $statsRow->avg_memory_mb, 2) : null,
-            'p50_duration_ms' => $p50,
-            'p95_duration_ms' => $p95,
-            'p99_duration_ms' => $p99,
-        ];
+            $p50 = $this->percentile($durations, 50);
+            $p95 = $this->percentile($durations, 95);
+            $p99 = $this->percentile($durations, 99);
 
-        // Throughput (per-minute for this entity)
-        /** @var EloquentStatisticsRepository $statsRepo */
-        $statsRepo = $this->statsRepository;
-        $throughput = $statsRepo->computeThroughputByMinute(60, [$column => $value]);
+            $stats = [
+                'total' => $total,
+                'completed' => $completed,
+                'failed' => $failed,
+                'success_rate' => $finished > 0 ? round(($completed / $finished) * 100, 2) : 0,
+                'avg_duration_ms' => $statsRow && $statsRow->avg_duration_ms !== null ? round((float) $statsRow->avg_duration_ms, 2) : null,
+                'max_duration_ms' => $statsRow && $statsRow->max_duration_ms !== null ? (int) $statsRow->max_duration_ms : null,
+                'min_duration_ms' => $statsRow && $statsRow->min_duration_ms !== null ? (int) $statsRow->min_duration_ms : null,
+                'avg_memory_mb' => $statsRow && $statsRow->avg_memory_mb !== null ? round((float) $statsRow->avg_memory_mb, 2) : null,
+                'p50_duration_ms' => $p50,
+                'p95_duration_ms' => $p95,
+                'p99_duration_ms' => $p99,
+            ];
 
-        // Recent jobs (last 20) with identifiable summary from payload
-        $recentJobs = DB::table($table)
-            ->where($column, $value)
-            ->orderByDesc('queued_at')
-            ->limit(20)
-            ->get()
-            ->map(function ($job) {
-                $summary = $this->extractJobSummary($job->payload, $job->display_name);
+            // Throughput (per-minute for this entity)
+            /** @var EloquentStatisticsRepository $statsRepo */
+            $statsRepo = $this->statsRepository;
+            $throughput = $statsRepo->computeThroughputByMinute(60, [$column => $value]);
 
-                return [
-                    'uuid' => $job->uuid,
-                    'job_class' => class_basename($job->job_class),
-                    'summary' => $summary,
-                    'queue' => $job->queue,
-                    'status' => $job->status,
-                    'attempt' => $job->attempt,
-                    'server' => $job->server_name,
-                    'duration_ms' => $job->duration_ms !== null ? (int) $job->duration_ms : null,
-                    'duration' => $job->duration_ms !== null ? number_format((int) $job->duration_ms).'ms' : '-',
-                    'queued_at' => $job->queued_at,
-                    'error' => $job->exception_message,
-                ];
-            })
-            ->values()
-            ->all();
+            // Recent jobs (last 20) with identifiable summary from payload
+            $recentJobs = DB::table($table)
+                ->where($column, $value)
+                ->orderByDesc('queued_at')
+                ->limit(20)
+                ->get()
+                ->map(function ($job) {
+                    $summary = $this->extractJobSummary($job->payload, $job->display_name);
 
-        // Failure patterns (top exception classes for this entity)
-        $failurePatterns = DB::table($table)
-            ->select([
-                'exception_class',
-                DB::raw('COUNT(*) as count'),
-            ])
-            ->where($column, $value)
-            ->whereNotNull('exception_class')
-            ->groupBy('exception_class')
-            ->orderByDesc('count')
-            ->limit(10)
-            ->get()
-            ->map(fn ($row) => [
-                'exception_class' => $row->exception_class,
-                'count' => (int) $row->count,
-            ])
-            ->values()
-            ->all();
+                    return [
+                        'uuid' => $job->uuid,
+                        'job_class' => class_basename($job->job_class),
+                        'summary' => $summary,
+                        'queue' => $job->queue,
+                        'status' => $job->status,
+                        'attempt' => $job->attempt,
+                        'server' => $job->server_name,
+                        'duration_ms' => $job->duration_ms !== null ? (int) $job->duration_ms : null,
+                        'duration' => $job->duration_ms !== null ? number_format((int) $job->duration_ms).'ms' : '-',
+                        'queued_at' => $job->queued_at,
+                        'error' => $job->exception_message,
+                    ];
+                })
+                ->values()
+                ->all();
 
-        $result = [
-            'entity' => [
-                'type' => $type,
-                'value' => $value,
-            ],
-            'stats' => $stats,
-            'throughput' => $throughput,
-            'recent_jobs' => $recentJobs,
-            'failure_patterns' => $failurePatterns,
-        ];
+            // Failure patterns (top exception classes for this entity)
+            $failurePatterns = DB::table($table)
+                ->select([
+                    'exception_class',
+                    DB::raw('COUNT(*) as count'),
+                ])
+                ->where($column, $value)
+                ->whereNotNull('exception_class')
+                ->groupBy('exception_class')
+                ->orderByDesc('count')
+                ->limit(10)
+                ->get()
+                ->map(fn ($row) => [
+                    'exception_class' => $row->exception_class,
+                    'count' => (int) $row->count,
+                ])
+                ->values()
+                ->all();
 
-        cache()->put($cacheKey, $result, 30);
+            return [
+                'entity' => [
+                    'type' => $type,
+                    'value' => $value,
+                ],
+                'stats' => $stats,
+                'throughput' => $throughput,
+                'recent_jobs' => $recentJobs,
+                'failure_patterns' => $failurePatterns,
+            ];
+        }, 30);
 
         return response()->json($result);
     }

--- a/src/LaravelQueueMonitorServiceProvider.php
+++ b/src/LaravelQueueMonitorServiceProvider.php
@@ -136,9 +136,7 @@ class LaravelQueueMonitorServiceProvider extends PackageServiceProvider
         ];
 
         foreach ($autoscaleEvents as $eventClass => $method) {
-            if (class_exists($eventClass)) {
-                Event::listen($eventClass, [ScalingEventListener::class, $method]);
-            }
+            Event::listen($eventClass, [ScalingEventListener::class, $method]);
         }
     }
 

--- a/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
+++ b/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
@@ -97,7 +97,7 @@ final class EloquentJobMonitorRepository implements JobMonitorRepositoryContract
         $this->applyFilters($query, $filters);
 
         return $query
-            ->orderBy($filters->sortBy, $filters->sortDirection)
+            ->orderBy($filters->sortBy, $filters->sortDirectionForQuery())
             ->limit($filters->limit)
             ->offset($filters->offset)
             ->get();

--- a/src/Services/DashboardCacheService.php
+++ b/src/Services/DashboardCacheService.php
@@ -27,6 +27,29 @@ final class DashboardCacheService
         $cache->increment($versionKey);
     }
 
+    public function remember(string $key, \Closure $callback, ?int $ttl = null): mixed
+    {
+        if (! config('queue-monitor.cache.enabled', true)) {
+            return $callback();
+        }
+
+        /** @var int $cacheTtl */
+        $cacheTtl = config('queue-monitor.cache.ttl', 300);
+
+        $cache = $this->cacheStore();
+        $fullKey = $this->scopedKey($key);
+        $cached = $cache->get($fullKey);
+
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $value = $callback();
+        $cache->put($fullKey, $value, $ttl ?? $cacheTtl);
+
+        return $value;
+    }
+
     private function version(): int
     {
         if (! config('queue-monitor.cache.enabled', true)) {

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -172,6 +172,24 @@ test('drill-down endpoint returns queue detail', function () {
     expect($response->json('stats.total'))->toBe(7);
 });
 
+test('drill-down cache refreshes after repository update', function () {
+    config()->set('queue-monitor.cache.enabled', true);
+
+    $job = JobMonitor::factory()->create(['queue' => 'alpha']);
+
+    $first = getJson(route('queue-monitor.dashboard.drill-down', ['type' => 'queue', 'value' => 'alpha']));
+    $first->assertOk();
+    expect($first->json('stats.total'))->toBe(1);
+
+    app(JobMonitorRepositoryContract::class)->update($job->uuid, [
+        'queue' => 'beta',
+    ]);
+
+    $second = getJson(route('queue-monitor.dashboard.drill-down', ['type' => 'queue', 'value' => 'alpha']));
+    $second->assertOk();
+    expect($second->json('stats.total'))->toBe(0);
+});
+
 test('drill-down endpoint returns server detail', function () {
     JobMonitor::factory()->count(3)->create(['server_name' => 'prod-01']);
 

--- a/tests/Feature/EdgeCases/DashboardEdgeCaseTest.php
+++ b/tests/Feature/EdgeCases/DashboardEdgeCaseTest.php
@@ -133,6 +133,23 @@ test('jobs endpoint handles multiple status filters', function () {
     expect($response->json('meta.total'))->toBe(3);
 });
 
+test('jobs endpoint ignores invalid filter values', function () {
+    JobMonitor::factory()->count(2)->create(['status' => JobStatus::COMPLETED]);
+    JobMonitor::factory()->count(1)->create(['status' => JobStatus::FAILED]);
+
+    $response = getJson(route('queue-monitor.dashboard.jobs', [
+        'statuses' => ['failed', 'not-a-status'],
+        'queued_after' => 'not-a-date',
+        'limit' => 0,
+        'offset' => -10,
+    ]));
+
+    $response->assertOk();
+    expect($response->json('meta.total'))->toBe(1);
+    expect($response->json('meta.limit'))->toBe(1);
+    expect($response->json('meta.offset'))->toBe(0);
+});
+
 // Deleted/renamed job class
 test('job detail works when job class no longer exists', function () {
     $job = JobMonitor::factory()->create([


### PR DESCRIPTION
## What changed

- Consolidated dashboard auto-refresh behind a single `refreshCurrentView()` flow.
- Added per-scope in-flight and pending refresh guards to avoid overlapping polling/retry storms.
- Let live refresh update job detail, analytics, infrastructure, health, and drill-down views instead of only a subset of tabs.
- Made autoscale's optional 5s refresh respect the global Live/Pause toggle and avoid double polling with the global interval.
- Moved drill-down caching onto the versioned dashboard cache service so repository updates invalidate cached drill-down payloads.
- Hardened `JobFilterData` parsing for invalid statuses/dates and clamped limit/offset input.
- Cleaned up PHPStan issues around sort direction and optional autoscale event registration.

## Why

The dashboard had several inconsistent refresh paths: health badges could go stale, some tabs stayed static while the UI said Live, autoscale could poll from two intervals, and retrying fetches could overlap. Drill-down data also used an isolated cache key that was not invalidated with the rest of the dashboard caches.

## Impact

Users should see fresher and more predictable dashboard state, especially while watching active jobs, drill-downs, autoscale data, and health changes. Bad filter query parameters no longer risk throwing before the endpoint can respond.

## Validation

- `composer format`
- `composer analyse`
- `vendor/bin/pest tests/Feature/DashboardControllerTest.php tests/Feature/EdgeCases/DashboardEdgeCaseTest.php`
- `composer test`