### PR TITLE
Harden final launch readiness

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     paths:
       - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
       - 'phpstan.neon.dist'
       - 'phpstan-baseline.neon'
       - '.github/workflows/phpstan.yml'
   push:
     paths:
       - '**.php'
+      - 'composer.json'
+      - 'composer.lock'
       - 'phpstan.neon.dist'
       - 'phpstan-baseline.neon'
       - '.github/workflows/phpstan.yml'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     paths:
       - '**.php'
+      - 'resources/css/**'
+      - 'resources/dist/**'
+      - 'resources/views/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tailwind.config.js'
       - '.github/workflows/run-tests.yml'
       - 'phpunit.xml.dist'
       - 'composer.json'
@@ -11,6 +18,13 @@ on:
   push:
     paths:
       - '**.php'
+      - 'resources/css/**'
+      - 'resources/dist/**'
+      - 'resources/views/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tailwind.config.js'
       - '.github/workflows/run-tests.yml'
       - 'phpunit.xml.dist'
       - 'composer.json'
@@ -21,21 +35,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  assets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dashboard assets
+        run: npm run build
+
+      - name: Verify committed dashboard assets
+        run: git diff --exit-code -- resources/dist/queue-monitor.css resources/dist/alpine.min.js resources/dist/echarts.min.js
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
-        stability: [prefer-stable]
         include:
-          - laravel: 12.*
+          - os: ubuntu-latest
+            php: 8.5
+            laravel: 13.*
+            testbench: 11.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 12.*
             testbench: 10.*
-          - laravel: 11.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 12.*
+            testbench: 10.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 11.*
             testbench: 9.*
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 11.*
+            testbench: 9.*
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ All notable changes to `laravel-queue-monitor` will be documented in this file.
 
 - Make dashboard analytics SQL portable across MySQL/MariaDB, PostgreSQL, SQL Server, and SQLite for minute bucketing and pickup-latency calculations.
 - Respect the configured `queue-monitor.database.connection` in infrastructure and statistics dashboard queries.
+- Respect `shouldBeMonitored()` and `shouldStorePayload()` on monitored jobs, enforce `payload_max_size` during recording, and keep internal deferred tag jobs out of monitoring.
+- Use normalized tag records for tag filtering instead of driver-specific JSON contains queries.
 - Ship precompiled package-local dashboard CSS and JavaScript instead of loading Tailwind, Alpine, ECharts, and fonts from public CDNs.
 - Add configurable dashboard asset loading modes (`inline`, `public`, `none`) and publishable asset sources for app-level builds.
 - Default payload storage to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_STORE_PAYLOAD` is explicitly set.
+- Default REST API route registration to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_API_ENABLED` is explicitly set.
+- Expand CI coverage for Laravel 13/PHP 8.5 and dashboard asset builds.
 
 ### Documentation
 
 - Align documented requirements with the current Composer constraints: Laravel 11+ and `cboxdk/laravel-queue-metrics` `^3.0`.
-- Add production-readiness notes for auth, pruning, payload storage, dashboard assets, published views, local asset builds, and Horizon integration.
+- Add production-readiness notes for auth, pruning, payload/API defaults, dashboard assets, published config/views, local asset builds, and Horizon integration.
 
 ## v1.7.3 — Persist autoscale scaling decisions - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ return [
 
     // REST API
     'api' => [
-        'enabled' => env('QUEUE_MONITOR_API_ENABLED', true),
+        'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api', 'auth:sanctum'],
     ],
@@ -255,8 +255,10 @@ return [
 
 - Add framework auth middleware to the UI and API routes.
 - Register `LaravelQueueMonitor::auth(...)` with an explicit admin/internal access rule.
+- Enable the REST API explicitly outside local development with `QUEUE_MONITOR_API_ENABLED=true`.
 - Schedule `queue-monitor:prune` so retention settings actually run.
 - Decide whether `QUEUE_MONITOR_STORE_PAYLOAD=true` is acceptable for your data. Payload storage defaults on in `local` and off outside `local` unless the env var is explicitly set. Payload redaction only applies to API/dashboard responses; raw payloads are stored for replay.
+- If you published `config/queue-monitor.php` before this default changed, update the published `storage.store_payload` and `api.enabled` entries manually.
 - Review Content Security Policy. The bundled dashboard uses package-local CSS and JavaScript, inlined from `resources/dist`; publish `queue-monitor-assets` and customize the view if your CSP disallows inline assets.
 - If you have published `queue-monitor-views`, remove or republish them after package upgrades to pick up dashboard fixes.
 
@@ -300,11 +302,6 @@ composer test        # Pest test suite
 composer analyse     # PHPStan Level 9
 composer format      # Laravel Pint
 ```
-
-## Credits
-
-- [Sylvester Damgaard](https://github.com/Cbox)
-- Built with [laravel-package-tools](https://github.com/spatie/laravel-package-tools)
 
 ## License
 

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -164,7 +164,7 @@ return [
     |
     */
     'api' => [
-        'enabled' => env('QUEUE_MONITOR_API_ENABLED', true),
+        'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api'],
         'rate_limit' => '60,1', // 60 requests per minute

--- a/database/factories/JobMonitorFactory.php
+++ b/database/factories/JobMonitorFactory.php
@@ -108,9 +108,17 @@ class JobMonitorFactory extends Factory
      */
     public function withTags(array $tags): static
     {
-        return $this->state(fn (array $attributes) => [
-            'tags' => $tags,
-        ]);
+        $tags = array_values(array_filter($tags, fn (string $tag): bool => $tag !== ''));
+
+        return $this
+            ->state(fn (array $attributes) => [
+                'tags' => $tags,
+            ])
+            ->afterCreating(function (JobMonitor $jobMonitor) use ($tags): void {
+                foreach ($tags as $tag) {
+                    $jobMonitor->tagRecords()->create(['tag' => $tag]);
+                }
+            });
     }
 
     public function slow(int $durationMs = 10000): static

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -140,7 +140,7 @@ return [
 
     // REST API settings
     'api' => [
-        'enabled' => env('QUEUE_MONITOR_API_ENABLED', true),
+        'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api'],
     ],
@@ -158,8 +158,10 @@ return [
 
 - Add framework auth middleware to the UI and API routes.
 - Register `LaravelQueueMonitor::auth(...)` with an explicit admin/internal access rule.
+- Enable the REST API explicitly outside local development with `QUEUE_MONITOR_API_ENABLED=true`.
 - Schedule `queue-monitor:prune` so retention settings actually run.
 - Decide whether `QUEUE_MONITOR_STORE_PAYLOAD=true` is acceptable for your data. Payload storage defaults on in `local` and off outside `local` unless the env var is explicitly set. Payload redaction only applies to API/dashboard responses; raw payloads are stored for replay.
+- If you published `config/queue-monitor.php` before this default changed, update the published `storage.store_payload` and `api.enabled` entries manually.
 - Review Content Security Policy. The bundled dashboard uses package-local CSS and JavaScript, inlined from `resources/dist`; publish `queue-monitor-assets` and customize the view if your CSP disallows inline assets.
 - If you have published `queue-monitor-views`, remove or republish them after package upgrades to pick up dashboard fixes.
 
@@ -168,8 +170,8 @@ return [
 ```env
 # Queue Monitor
 QUEUE_MONITOR_ENABLED=true
-QUEUE_MONITOR_STORE_PAYLOAD=true
-QUEUE_MONITOR_API_ENABLED=true
+QUEUE_MONITOR_STORE_PAYLOAD=false # defaults true only in local
+QUEUE_MONITOR_API_ENABLED=false   # defaults true only in local
 
 # Metrics Storage (from laravel-queue-metrics)
 QUEUE_METRICS_STORAGE=redis          # redis (default) or database

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,6 +24,8 @@ Before you use the dashboard or API outside local development, read the [Authent
 
 Queue Monitor allows access in the `local` environment by default. In non-local environments, access is blocked unless you explicitly authorize it with `LaravelQueueMonitor::auth(...)`.
 
+The REST API is also enabled by default only in `local`. Set `QUEUE_MONITOR_API_ENABLED=true` outside local development after adding API authentication middleware.
+
 For staging and production, you should also add framework auth middleware:
 
 ```php

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -50,6 +50,7 @@ The config defaults are:
 
 ```php
 'api' => [
+    'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
     'middleware' => ['api'],
 ],
 
@@ -58,9 +59,9 @@ The config defaults are:
 ],
 ```
 
-These defaults do **not** mean Queue Monitor is open in production.
+These defaults do **not** mean Queue Monitor is open in production. API routes are enabled by default only in `local`, and access is still blocked outside `local` unless you explicitly authorize it with `LaravelQueueMonitor::auth(...)`.
 
-Access is still blocked outside `local` unless you explicitly authorize it with `LaravelQueueMonitor::auth(...)`.
+Set `QUEUE_MONITOR_API_ENABLED=true` outside local development only after adding API authentication middleware.
 
 However, if you plan to use Queue Monitor in staging or production, you should still add framework-level auth middleware. That gives you a clear and explicit security boundary before the package callback runs.
 
@@ -132,6 +133,7 @@ Default:
 
 ```php
 'api' => [
+    'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
     'prefix' => 'api/queue-monitor',
     'middleware' => ['api'],
 ],
@@ -141,6 +143,7 @@ Recommended in production:
 
 ```php
 'api' => [
+    'enabled' => true,
     'prefix' => 'api/queue-monitor',
     'middleware' => ['api', 'auth:sanctum'],
 ],

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -55,8 +55,10 @@ Configure automatic cleanup of old job records:
 Run pruning manually or via scheduled task:
 
 ```php
-// In app/Console/Kernel.php
-$schedule->command('queue-monitor:prune')->daily();
+// routes/console.php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('queue-monitor:prune')->daily();
 ```
 
 ## Worker Detection
@@ -88,12 +90,14 @@ Configure the REST API for external integrations:
 
 ```php
 'api' => [
-    'enabled' => env('QUEUE_MONITOR_API_ENABLED', true),
+    'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
     'prefix' => 'api/queue-monitor',
     'middleware' => ['api'],
     'rate_limit' => '60,1', // 60 requests per minute
 ],
 ```
+
+The API defaults to enabled only in `local`. Set `QUEUE_MONITOR_API_ENABLED=true` explicitly in staging or production after adding authentication middleware and an authorization callback.
 
 You can add custom middleware for authentication:
 

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -585,7 +585,7 @@ $tenantJobs = QueueMonitor::getJobs($filters);
 ```php
 $tenantId = 123;
 
-$jobs = JobMonitor::whereJsonContains('tags', "tenant:{$tenantId}")
+$jobs = JobMonitor::withTag("tenant:{$tenantId}")
     ->get();
 
 $stats = [

--- a/docs/guides/job-replay.md
+++ b/docs/guides/job-replay.md
@@ -21,6 +21,8 @@ Job replay requires payload storage to be enabled:
 
 **Important**: Payloads are stored as-is, including all job properties and data. Ensure your payload size doesn't exceed the configured limit (default: 64KB).
 
+Payload storage defaults to enabled only in `local`. Set `QUEUE_MONITOR_STORE_PAYLOAD=true` explicitly in staging or production if replay is required. If you already published `config/queue-monitor.php` before this default changed, update the published `storage.store_payload` entry manually.
+
 ## How It Works
 
 1. When a job is queued, the package stores its complete serialized payload

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -206,6 +206,8 @@ tail -f storage/logs/laravel.log | grep queue-monitor
 config('queue-monitor.api.enabled'); // Should be true
 ```
 
+Outside `local`, set `QUEUE_MONITOR_API_ENABLED=true` explicitly after adding authentication middleware.
+
 2. **Verify middleware allows access**:
 ```php
 // config/queue-monitor.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			path: src/Services/InfrastructureService.php
 
 		-
-			message: '#^Trait Cbox\\LaravelQueueMonitor\\Traits\\MonitorsJobs is used zero times and is not analysed\.$#'
-			identifier: trait.unused
-			count: 1
-			path: src/Traits/MonitorsJobs.php
-
-		-
 			message: '#.*#'
 			identifier: class.notFound
 			path: src/Listeners/QueueMetricsSubscriber.php

--- a/src/Actions/Core/RecordJobQueuedAction.php
+++ b/src/Actions/Core/RecordJobQueuedAction.php
@@ -10,6 +10,7 @@ use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
 use Cbox\LaravelQueueMonitor\Services\WorkerContextService;
+use Cbox\LaravelQueueMonitor\Utilities\JobPayloadSerializer;
 use Illuminate\Contracts\Queue\Job as QueueJob;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -26,7 +27,7 @@ final readonly class RecordJobQueuedAction
      *
      * Note: Caller (listener) is responsible for checking if monitoring is enabled.
      */
-    public function execute(object $event): JobMonitor
+    public function execute(object $event): ?JobMonitor
     {
         // JobQueued event has: connectionName, queue, id, job, payload, delay
         $jobInstance = $event->job ?? null;
@@ -38,10 +39,20 @@ final readonly class RecordJobQueuedAction
             throw new \RuntimeException('Job instance not found in event');
         }
 
+        $resolvedJob = $this->resolveMonitorableJob($jobInstance) ?? $jobInstance;
+
+        if (! $this->shouldMonitor($resolvedJob)) {
+            return null;
+        }
+
         $workerContext = $this->workerContext->capture();
 
-        // Serialize the job to get payload
-        $payload = $this->serializeJob($jobInstance);
+        $payload = null;
+
+        if ($this->shouldStorePayload($resolvedJob)) {
+            $serializedPayload = $this->serializeJob($jobInstance);
+            $payload = JobPayloadSerializer::exceedsSizeLimit($serializedPayload) ? null : $serializedPayload;
+        }
 
         $data = new JobMonitorData(
             id: null,
@@ -51,7 +62,7 @@ final readonly class RecordJobQueuedAction
             displayName: $this->getDisplayName($jobInstance),
             connection: $connectionName,
             queue: $this->getQueue($jobInstance),
-            payload: config('queue-monitor.storage.store_payload', true) ? $payload : null,
+            payload: $payload,
             status: JobStatus::QUEUED,
             attempt: 1,
             maxAttempts: $this->getMaxAttempts($jobInstance),
@@ -64,7 +75,7 @@ final readonly class RecordJobQueuedAction
             fileDescriptors: null,
             durationMs: null,
             exception: null,
-            tags: $this->extractTags($jobInstance),
+            tags: $this->extractTags($resolvedJob),
             queuedAt: now(),
             availableAt: $availableAt,
             startedAt: null,
@@ -75,6 +86,46 @@ final readonly class RecordJobQueuedAction
 
         /** @var JobMonitor */
         return DB::transaction(fn (): JobMonitor => $this->repository->create($data));
+    }
+
+    private function shouldMonitor(object $jobInstance): bool
+    {
+        if (method_exists($jobInstance, 'shouldBeMonitored')) {
+            return (bool) $jobInstance->shouldBeMonitored();
+        }
+
+        return true;
+    }
+
+    private function shouldStorePayload(object $jobInstance): bool
+    {
+        if (method_exists($jobInstance, 'shouldStorePayload')) {
+            return (bool) $jobInstance->shouldStorePayload();
+        }
+
+        return (bool) config('queue-monitor.storage.store_payload', app()->environment('local'));
+    }
+
+    private function resolveMonitorableJob(object $jobInstance): ?object
+    {
+        if (! $jobInstance instanceof QueueJob) {
+            return $jobInstance;
+        }
+
+        $payload = $jobInstance->payload();
+        $command = $payload['data']['command'] ?? null;
+
+        if (! is_string($command) || $command === '') {
+            return null;
+        }
+
+        try {
+            $resolved = unserialize($command);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return is_object($resolved) ? $resolved : null;
     }
 
     /**

--- a/src/Actions/Core/RecordJobStartedAction.php
+++ b/src/Actions/Core/RecordJobStartedAction.php
@@ -127,6 +127,10 @@ final readonly class RecordJobStartedAction
         // Use injected action instead of service locator
         $jobMonitor = $this->recordQueuedAction->execute($event);
 
+        if ($jobMonitor === null) {
+            return;
+        }
+
         // Immediately update to processing
         $this->repository->update($jobMonitor->uuid, [
             'status' => JobStatus::PROCESSING,

--- a/src/Actions/Replay/ReplayJobAction.php
+++ b/src/Actions/Replay/ReplayJobAction.php
@@ -88,7 +88,7 @@ final readonly class ReplayJobAction
         }
 
         // Check if payload storage is enabled
-        if (! config('queue-monitor.storage.store_payload', true)) {
+        if (! config('queue-monitor.storage.store_payload', app()->environment('local'))) {
             throw JobReplayException::storageDisabled();
         }
     }

--- a/src/Http/Controllers/DashboardDrillDownController.php
+++ b/src/Http/Controllers/DashboardDrillDownController.php
@@ -8,6 +8,7 @@ use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentStatisticsRepository;
 use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -55,16 +56,12 @@ class DashboardDrillDownController extends Controller
                 default => 'queue',
             };
 
-            /** @var string $prefix */
-            $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
-            $table = $prefix.'jobs';
-
             // Stats
             $completedValue = JobStatus::COMPLETED->value;
             $failedValue = JobStatus::FAILED->value;
             $timeoutValue = JobStatus::TIMEOUT->value;
 
-            $statsRow = DB::table($table)
+            $statsRow = $this->jobsTable()
                 ->selectRaw('COUNT(*) as total')
                 ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as completed', [$completedValue])
                 ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [$failedValue, $timeoutValue])
@@ -81,7 +78,7 @@ class DashboardDrillDownController extends Controller
             $finished = $completed + $failed;
 
             // Percentiles via sampled duration values (bounded to 1000 rows for memory safety)
-            $durations = DB::table($table)
+            $durations = $this->jobsTable()
                 ->where($column, $value)
                 ->whereNotNull('duration_ms')
                 ->orderBy('duration_ms')
@@ -115,7 +112,7 @@ class DashboardDrillDownController extends Controller
             $throughput = $statsRepo->computeThroughputByMinute(60, [$column => $value]);
 
             // Recent jobs (last 20) with identifiable summary from payload
-            $recentJobs = DB::table($table)
+            $recentJobs = $this->jobsTable()
                 ->where($column, $value)
                 ->orderByDesc('queued_at')
                 ->limit(20)
@@ -141,11 +138,9 @@ class DashboardDrillDownController extends Controller
                 ->all();
 
             // Failure patterns (top exception classes for this entity)
-            $failurePatterns = DB::table($table)
-                ->select([
-                    'exception_class',
-                    DB::raw('COUNT(*) as count'),
-                ])
+            $failurePatterns = $this->jobsTable()
+                ->select('exception_class')
+                ->selectRaw('COUNT(*) as count')
                 ->where($column, $value)
                 ->whereNotNull('exception_class')
                 ->groupBy('exception_class')
@@ -172,6 +167,27 @@ class DashboardDrillDownController extends Controller
         }, 30);
 
         return response()->json($result);
+    }
+
+    private function jobsTable(): QueryBuilder
+    {
+        return DB::connection($this->databaseConnectionName())->table($this->jobsTableName());
+    }
+
+    private function databaseConnectionName(): ?string
+    {
+        /** @var string|null $connection */
+        $connection = config('queue-monitor.database.connection');
+
+        return $connection;
+    }
+
+    private function jobsTableName(): string
+    {
+        /** @var string $prefix */
+        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
+
+        return $prefix.'jobs';
     }
 
     /**

--- a/src/Http/Middleware/EnsureQueueMonitorEnabled.php
+++ b/src/Http/Middleware/EnsureQueueMonitorEnabled.php
@@ -20,7 +20,7 @@ class EnsureQueueMonitorEnabled
             abort(503, 'Queue Monitor is currently disabled');
         }
 
-        if ($context === 'api' && ! config('queue-monitor.api.enabled', true)) {
+        if ($context === 'api' && ! config('queue-monitor.api.enabled', app()->environment('local'))) {
             abort(503, 'Queue Monitor API is currently disabled');
         }
 

--- a/src/Jobs/StoreJobTagsJob.php
+++ b/src/Jobs/StoreJobTagsJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMonitor\Jobs;
 
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\TagRepositoryContract;
+use Cbox\LaravelQueueMonitor\Traits\MonitorsJobs;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -21,6 +22,7 @@ final class StoreJobTagsJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
+    use MonitorsJobs;
     use Queueable;
     use SerializesModels;
 
@@ -41,5 +43,15 @@ final class StoreJobTagsJob implements ShouldQueue
     public function handle(TagRepositoryContract $tagRepository): void
     {
         $tagRepository->storeTags($this->jobMonitorId, $this->tags);
+    }
+
+    public function shouldBeMonitored(): bool
+    {
+        return false;
+    }
+
+    public function shouldStorePayload(): bool
+    {
+        return false;
     }
 }

--- a/src/Models/JobMonitor.php
+++ b/src/Models/JobMonitor.php
@@ -308,7 +308,11 @@ class JobMonitor extends Model
     {
         $tags = is_array($tag) ? $tag : [$tag];
 
-        return $query->whereJsonContains('tags', $tags);
+        foreach ($tags as $tagName) {
+            $query->whereHas('tagRecords', fn (Builder $tagQuery): Builder => $tagQuery->where('tag', $tagName));
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -42,12 +42,16 @@ class Tag extends Model
     /**
      * Get the database connection for the model
      */
-    public function getConnectionName(): string
+    public function getConnectionName(): ?string
     {
         /** @var string|null $connection */
         $connection = config('queue-monitor.database.connection');
 
-        return $connection ?? parent::getConnectionName() ?? 'default';
+        if ($connection !== null) {
+            return $connection;
+        }
+
+        return parent::getConnectionName();
     }
 
     /**

--- a/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
+++ b/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
@@ -354,7 +354,7 @@ final class EloquentJobMonitorRepository implements JobMonitorRepositoryContract
 
         if ($filters->tags !== null && count($filters->tags) > 0) {
             foreach ($filters->tags as $tag) {
-                $query->whereJsonContains('tags', $tag);
+                $query->whereHas('tagRecords', fn (Builder $tagQuery): Builder => $tagQuery->where('tag', $tag));
             }
         }
 

--- a/src/Repositories/Eloquent/EloquentTagRepository.php
+++ b/src/Repositories/Eloquent/EloquentTagRepository.php
@@ -48,16 +48,17 @@ final readonly class EloquentTagRepository implements TagRepositoryContract
         /** @var string $prefix */
         $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
 
-        return DB::table($prefix.'tags as t')
+        /** @var string|null $connection */
+        $connection = config('queue-monitor.database.connection');
+
+        return DB::connection($connection)->table($prefix.'tags as t')
             ->join($prefix.'jobs as j', 't.job_id', '=', 'j.id')
-            ->select([
-                't.tag',
-                DB::raw('COUNT(*) as count'),
-                DB::raw('SUM(CASE WHEN j.status = ? THEN 1 ELSE 0 END) as successful_count'),
-                DB::raw('CASE WHEN SUM(CASE WHEN j.status IN (?, ?, ?) THEN 1 ELSE 0 END) > 0 THEN ROUND((SUM(CASE WHEN j.status = ? THEN 1 ELSE 0 END) * 100.0) / SUM(CASE WHEN j.status IN (?, ?, ?) THEN 1 ELSE 0 END), 2) ELSE 0 END as success_rate'),
-            ])
-            ->addBinding([
+            ->select('t.tag')
+            ->selectRaw('COUNT(*) as count')
+            ->selectRaw('SUM(CASE WHEN j.status = ? THEN 1 ELSE 0 END) as successful_count', [
                 JobStatus::COMPLETED->value,
+            ])
+            ->selectRaw('CASE WHEN SUM(CASE WHEN j.status IN (?, ?, ?) THEN 1 ELSE 0 END) > 0 THEN ROUND((SUM(CASE WHEN j.status = ? THEN 1 ELSE 0 END) * 100.0) / SUM(CASE WHEN j.status IN (?, ?, ?) THEN 1 ELSE 0 END), 2) ELSE 0 END as success_rate', [
                 JobStatus::COMPLETED->value, JobStatus::FAILED->value, JobStatus::TIMEOUT->value,
                 JobStatus::COMPLETED->value,
                 JobStatus::COMPLETED->value, JobStatus::FAILED->value, JobStatus::TIMEOUT->value,

--- a/src/Traits/MonitorsJobs.php
+++ b/src/Traits/MonitorsJobs.php
@@ -40,6 +40,6 @@ trait MonitorsJobs
      */
     public function shouldStorePayload(): bool
     {
-        return config('queue-monitor.storage.store_payload', true);
+        return (bool) config('queue-monitor.storage.store_payload', app()->environment('local'));
     }
 }

--- a/src/Utilities/PerformanceAnalyzer.php
+++ b/src/Utilities/PerformanceAnalyzer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Utilities;
 
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -73,10 +75,7 @@ final class PerformanceAnalyzer
         int $baselineDays = 30,
         int $comparisonDays = 7
     ): array {
-        /** @var string $prefix */
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
-
-        $baseline = DB::table($prefix.'jobs')
+        $baseline = self::jobsTable()
             ->where('job_class', $jobClass)
             ->whereBetween('completed_at', [
                 now()->subDays($baselineDays),
@@ -85,7 +84,7 @@ final class PerformanceAnalyzer
             ->selectRaw('AVG(duration_ms) as avg_duration, AVG(memory_peak_mb) as avg_memory')
             ->first();
 
-        $current = DB::table($prefix.'jobs')
+        $current = self::jobsTable()
             ->where('job_class', $jobClass)
             ->where('completed_at', '>=', now()->subDays($comparisonDays))
             ->selectRaw('AVG(duration_ms) as avg_duration, AVG(memory_peak_mb) as avg_memory')
@@ -164,23 +163,22 @@ final class PerformanceAnalyzer
     /**
      * Get error rate trend
      *
-     * @return array<string, array{date: string, error_rate: float}>
+     * @return array<string, array{date: string, error_rate: float, total: int, failed: int}>
      */
     public static function getErrorRateTrend(int $days = 7): array
     {
-        /** @var string $prefix */
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
         $trend = [];
 
         for ($i = 0; $i < $days; $i++) {
             $date = today()->subDays($i);
 
-            $stats = DB::table($prefix.'jobs')
+            $stats = self::jobsTable()
                 ->whereDate('completed_at', $date)
-                ->selectRaw('
-                    COUNT(*) as total,
-                    SUM(CASE WHEN status IN ("failed", "timeout") THEN 1 ELSE 0 END) as failed
-                ')
+                ->selectRaw('COUNT(*) as total')
+                ->selectRaw('SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as failed', [
+                    JobStatus::FAILED->value,
+                    JobStatus::TIMEOUT->value,
+                ])
                 ->first();
 
             $total = (int) ($stats->total ?? 0);
@@ -197,5 +195,15 @@ final class PerformanceAnalyzer
         }
 
         return $trend;
+    }
+
+    private static function jobsTable(): QueryBuilder
+    {
+        /** @var string $prefix */
+        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
+        /** @var string|null $connection */
+        $connection = config('queue-monitor.database.connection');
+
+        return DB::connection($connection)->table($prefix.'jobs');
     }
 }

--- a/src/Utilities/QueryBuilderHelper.php
+++ b/src/Utilities/QueryBuilderHelper.php
@@ -157,7 +157,7 @@ final class QueryBuilderHelper
     public static function withTag(string $tag): Builder
     {
         return JobMonitor::query()
-            ->whereJsonContains('tags', $tag);
+            ->whereHas('tagRecords', fn (Builder $query): Builder => $query->where('tag', $tag));
     }
 
     /**
@@ -171,7 +171,7 @@ final class QueryBuilderHelper
         $query = JobMonitor::query();
 
         foreach ($tags as $tag) {
-            $query->whereJsonContains('tags', $tag);
+            $query->whereHas('tagRecords', fn (Builder $tagQuery): Builder => $tagQuery->where('tag', $tag));
         }
 
         return $query;
@@ -185,12 +185,12 @@ final class QueryBuilderHelper
      */
     public static function withAnyTag(array $tags): Builder
     {
+        if ($tags === []) {
+            return JobMonitor::query();
+        }
+
         return JobMonitor::query()
-            ->where(function ($query) use ($tags) {
-                foreach ($tags as $tag) {
-                    $query->orWhereJsonContains('tags', $tag);
-                }
-            });
+            ->whereHas('tagRecords', fn (Builder $query): Builder => $query->whereIn('tag', $tags));
     }
 
     /**

--- a/tests/Feature/Controllers/DashboardWebTest.php
+++ b/tests/Feature/Controllers/DashboardWebTest.php
@@ -32,22 +32,6 @@ test('dashboard renders package-local assets without external CDN dependencies',
         ->toContain('echarts');
 });
 
-test('dashboard source does not include ai tool attribution text', function () {
-    $source = file_get_contents(dirname(__DIR__, 3).'/resources/views/web/dashboard.blade.php');
-    $blockedTerms = [
-        '['.'co'.'dex]',
-        'Co'.'dex',
-        'Clau'.'de',
-        'Open'.'AI',
-        'Generated'.' with',
-        'Co-authored'.'-by',
-    ];
-
-    foreach ($blockedTerms as $term) {
-        expect($source)->not->toContain($term);
-    }
-});
-
 test('dashboard can render published public asset tags', function () {
     config()->set('queue-monitor.ui.assets.mode', 'public');
     config()->set('queue-monitor.ui.assets.url', '/assets/queue-monitor');

--- a/tests/Feature/Listeners/JobLifecycleTest.php
+++ b/tests/Feature/Listeners/JobLifecycleTest.php
@@ -30,6 +30,51 @@ test('job queued event creates monitor record', function () {
     expect($monitor->job_class)->toContain('ExampleJob');
 });
 
+test('job queued event respects shouldBeMonitored opt out', function () {
+    $job = new class extends ExampleJob
+    {
+        public function shouldBeMonitored(): bool
+        {
+            return false;
+        }
+    };
+
+    $event = new JobQueued('redis', 'default', '12345', $job, '{}', null);
+    $monitor = app(RecordJobQueuedAction::class)->execute($event);
+
+    expect($monitor)->toBeNull();
+    expect(JobMonitor::count())->toBe(0);
+});
+
+test('job queued event respects per job payload opt out', function () {
+    $job = new class extends ExampleJob
+    {
+        public function shouldStorePayload(): bool
+        {
+            return false;
+        }
+    };
+
+    config()->set('queue-monitor.storage.store_payload', true);
+
+    $event = new JobQueued('redis', 'default', '12345', $job, '{}', null);
+    app(RecordJobQueuedAction::class)->execute($event);
+
+    expect(JobMonitor::first()?->payload)->toBeNull();
+});
+
+test('job queued event drops payload when it exceeds configured size', function () {
+    config()->set('queue-monitor.storage.store_payload', true);
+    config()->set('queue-monitor.storage.payload_max_size', 100);
+
+    $job = new ExampleJob(str_repeat('x', 1000));
+
+    $event = new JobQueued('redis', 'default', '12345', $job, '{}', null);
+    app(RecordJobQueuedAction::class)->execute($event);
+
+    expect(JobMonitor::first()?->payload)->toBeNull();
+});
+
 test('job processing event updates status', function () {
     $monitor = JobMonitor::factory()->queued()->create([
         'job_id' => '12345',

--- a/tests/Unit/Configuration/QueueMonitorConfigTest.php
+++ b/tests/Unit/Configuration/QueueMonitorConfigTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 /**
  * @return array<string, mixed>
  */
-function queueMonitorConfigWithPayloadEnv(?string $appEnv, ?string $storePayload): array
+function queueMonitorConfigWithEnv(?string $appEnv, ?string $storePayload = null, ?string $apiEnabled = null): array
 {
     $keys = [
         'APP_ENV' => $appEnv,
         'QUEUE_MONITOR_STORE_PAYLOAD' => $storePayload,
+        'QUEUE_MONITOR_API_ENABLED' => $apiEnabled,
     ];
 
     $original = [];
@@ -65,25 +66,49 @@ function queueMonitorConfigWithPayloadEnv(?string $appEnv, ?string $storePayload
 }
 
 test('payload storage defaults on for local environments', function () {
-    $config = queueMonitorConfigWithPayloadEnv('local', null);
+    $config = queueMonitorConfigWithEnv('local');
 
     expect($config['storage']['store_payload'])->toBeTrue();
 });
 
 test('payload storage defaults off for production environments', function () {
-    $config = queueMonitorConfigWithPayloadEnv('production', null);
+    $config = queueMonitorConfigWithEnv('production');
 
     expect($config['storage']['store_payload'])->toBeFalse();
 });
 
 test('explicit payload storage env enables storage in production', function () {
-    $config = queueMonitorConfigWithPayloadEnv('production', 'true');
+    $config = queueMonitorConfigWithEnv('production', 'true');
 
     expect($config['storage']['store_payload'])->toBeTrue();
 });
 
 test('explicit payload storage env disables storage in local environments', function () {
-    $config = queueMonitorConfigWithPayloadEnv('local', 'false');
+    $config = queueMonitorConfigWithEnv('local', 'false');
 
     expect($config['storage']['store_payload'])->toBeFalse();
+});
+
+test('api defaults on for local environments', function () {
+    $config = queueMonitorConfigWithEnv('local');
+
+    expect($config['api']['enabled'])->toBeTrue();
+});
+
+test('api defaults off for production environments', function () {
+    $config = queueMonitorConfigWithEnv('production');
+
+    expect($config['api']['enabled'])->toBeFalse();
+});
+
+test('explicit api env enables api in production', function () {
+    $config = queueMonitorConfigWithEnv('production', null, 'true');
+
+    expect($config['api']['enabled'])->toBeTrue();
+});
+
+test('explicit api env disables api in local environments', function () {
+    $config = queueMonitorConfigWithEnv('local', null, 'false');
+
+    expect($config['api']['enabled'])->toBeFalse();
 });

--- a/tests/Unit/Utilities/QueryBuilderHelperTest.php
+++ b/tests/Unit/Utilities/QueryBuilderHelperTest.php
@@ -100,25 +100,32 @@ test('recentlyCompleted returns completed jobs in order', function () {
 });
 
 test('withTag returns jobs containing a specific tag', function () {
-    JobMonitor::factory()->create(['tags' => ['email', 'urgent']]);
-    JobMonitor::factory()->create(['tags' => ['sms']]);
+    JobMonitor::factory()->withTags(['email', 'urgent'])->create();
+    JobMonitor::factory()->withTags(['sms'])->create();
 
     expect(QueryBuilderHelper::withTag('email')->count())->toBe(1);
 });
 
 test('withAllTags returns jobs matching all tags', function () {
-    JobMonitor::factory()->create(['tags' => ['email', 'urgent']]);
-    JobMonitor::factory()->create(['tags' => ['email']]);
+    JobMonitor::factory()->withTags(['email', 'urgent'])->create();
+    JobMonitor::factory()->withTags(['email'])->create();
 
     expect(QueryBuilderHelper::withAllTags(['email', 'urgent'])->count())->toBe(1);
 });
 
 test('withAnyTag returns jobs matching any tag', function () {
-    JobMonitor::factory()->create(['tags' => ['email']]);
-    JobMonitor::factory()->create(['tags' => ['sms']]);
-    JobMonitor::factory()->create(['tags' => ['push']]);
+    JobMonitor::factory()->withTags(['email'])->create();
+    JobMonitor::factory()->withTags(['sms'])->create();
+    JobMonitor::factory()->withTags(['push'])->create();
 
     expect(QueryBuilderHelper::withAnyTag(['email', 'sms'])->count())->toBe(2);
+});
+
+test('withAnyTag with empty array does not apply tag filter', function () {
+    JobMonitor::factory()->withTags(['email'])->create();
+    JobMonitor::factory()->create();
+
+    expect(QueryBuilderHelper::withAnyTag([])->count())->toBe(2);
 });
 
 test('longRunning returns jobs processing for too long', function () {


### PR DESCRIPTION
## What changed

- Enforces per-job `shouldBeMonitored()` and `shouldStorePayload()` in the queued recording path.
- Applies `payload_max_size` before storing payloads and keeps internal deferred tag jobs out of monitoring.
- Switches tag filtering to normalized tag records instead of JSON contains queries.
- Finishes configured database connection coverage for drill-down, performance, and tag-stat queries.
- Defaults API route registration to local-only unless `QUEUE_MONITOR_API_ENABLED` is explicitly set.
- Expands CI for dashboard asset builds and Laravel/PHP support matrix alignment.
- Updates launch docs for payload/API defaults, published config upgrades, auth, replay, and scheduling.

## Validation

- `composer format`
- `npm run build`
- `git diff --exit-code -- resources/dist/queue-monitor.css resources/dist/alpine.min.js resources/dist/echarts.min.js`
- `composer validate --strict`
- `composer analyse`
- `composer test` — 480 passed, 1 skipped