### PR TITLE
Add production readiness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ All notable changes to `laravel-queue-monitor` will be documented in this file.
 - Add configurable dashboard asset loading modes (`inline`, `public`, `none`) and publishable asset sources for app-level builds.
 - Default payload storage to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_STORE_PAYLOAD` is explicitly set.
 - Default REST API route registration to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_API_ENABLED` is explicitly set.
+- Add `queue-monitor:health --readiness` for launch configuration checks and make health thresholds configurable.
 - Expand CI coverage for Laravel 13/PHP 8.5 and dashboard asset builds.
 
 ### Documentation
 
 - Align documented requirements with the current Composer constraints: Laravel 11+ and `cboxdk/laravel-queue-metrics` `^3.0`.
-- Add production-readiness notes for auth, pruning, payload/API defaults, dashboard assets, published config/views, local asset builds, and Horizon integration.
+- Add production-readiness notes for auth, pruning, payload/API defaults, health readiness checks, dashboard assets, published config/views, local asset builds, and Horizon integration.
 
 ## v1.7.3 — Persist autoscale scaling decisions - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ return [
 - If you published `config/queue-monitor.php` before this default changed, update the published `storage.store_payload` and `api.enabled` entries manually.
 - Review Content Security Policy. The bundled dashboard uses package-local CSS and JavaScript, inlined from `resources/dist`; publish `queue-monitor-assets` and customize the view if your CSP disallows inline assets.
 - If you have published `queue-monitor-views`, remove or republish them after package upgrades to pick up dashboard fixes.
+- Run `php artisan queue-monitor:health --readiness` in staging or production to catch unsafe launch configuration.
 
 ### Dashboard Authentication
 

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -133,6 +133,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Health Checks
+    |--------------------------------------------------------------------------
+    |
+    | Tune health thresholds for different queue volumes and environments.
+    |
+    */
+    'health' => [
+        'stuck_job_minutes' => env('QUEUE_MONITOR_HEALTH_STUCK_JOB_MINUTES', 30),
+        'error_rate_threshold' => env('QUEUE_MONITOR_HEALTH_ERROR_RATE_THRESHOLD', 10.0),
+        'queued_jobs_threshold' => env('QUEUE_MONITOR_HEALTH_QUEUED_JOBS_THRESHOLD', 1000),
+        'processing_jobs_threshold' => env('QUEUE_MONITOR_HEALTH_PROCESSING_JOBS_THRESHOLD', 100),
+        'storage_max_mb' => env('QUEUE_MONITOR_HEALTH_STORAGE_MAX_MB', 1000),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Metrics Time Window
     |--------------------------------------------------------------------------
     |

--- a/docs/advanced/advanced-usage.md
+++ b/docs/advanced/advanced-usage.md
@@ -605,40 +605,33 @@ Schedule::job(new PruneQueueMonitorJob)->daily();
 ### Building Custom Reports
 
 ```php
-use Cbox\LaravelQueueMonitor\Utilities\DatabaseExpressionHelper;
-use Illuminate\Support\Facades\DB;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 
 class CustomQueueAnalytics
 {
     public function getHourlyJobCount(): array
     {
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
-        $hourExpression = DatabaseExpressionHelper::hourBucket('queued_at', DB::connection()->getDriverName());
-
-        return DB::table($prefix.'jobs')
-            ->select([
-                DB::raw("{$hourExpression} as hour"),
-                DB::raw('COUNT(*) as count'),
-                DB::raw('AVG(duration_ms) as avg_duration'),
-            ])
+        return JobMonitor::query()
             ->whereBetween('queued_at', [now()->subDay(), now()])
-            ->groupBy(DB::raw($hourExpression))
-            ->orderBy(DB::raw($hourExpression))
-            ->get()
+            ->get(['queued_at', 'duration_ms'])
+            ->groupBy(fn (JobMonitor $job): string => $job->queued_at->format('Y-m-d H:00'))
+            ->map(fn ($jobs, string $hour): array => [
+                'hour' => $hour,
+                'count' => $jobs->count(),
+                'avg_duration' => $jobs->avg('duration_ms'),
+            ])
+            ->values()
             ->toArray();
     }
 
     public function getTopFailingJobs(int $limit = 10): array
     {
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
-
-        return DB::table($prefix.'jobs')
-            ->select([
-                'job_class',
-                DB::raw('COUNT(*) as failure_count'),
-                DB::raw('MAX(completed_at) as last_failure'),
-            ])
-            ->where('status', 'failed')
+        return JobMonitor::query()
+            ->select('job_class')
+            ->selectRaw('COUNT(*) as failure_count')
+            ->selectRaw('MAX(completed_at) as last_failure')
+            ->where('status', JobStatus::FAILED->value)
             ->whereDate('completed_at', '>=', now()->subDays(7))
             ->groupBy('job_class')
             ->orderByDesc('failure_count')

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -164,6 +164,7 @@ return [
 - If you published `config/queue-monitor.php` before this default changed, update the published `storage.store_payload` and `api.enabled` entries manually.
 - Review Content Security Policy. The bundled dashboard uses package-local CSS and JavaScript, inlined from `resources/dist`; publish `queue-monitor-assets` and customize the view if your CSP disallows inline assets.
 - If you have published `queue-monitor-views`, remove or republish them after package upgrades to pick up dashboard fixes.
+- Run `php artisan queue-monitor:health --readiness` in staging or production to catch unsafe launch configuration.
 
 ## Environment Variables
 
@@ -172,6 +173,11 @@ return [
 QUEUE_MONITOR_ENABLED=true
 QUEUE_MONITOR_STORE_PAYLOAD=false # defaults true only in local
 QUEUE_MONITOR_API_ENABLED=false   # defaults true only in local
+QUEUE_MONITOR_HEALTH_STUCK_JOB_MINUTES=30
+QUEUE_MONITOR_HEALTH_ERROR_RATE_THRESHOLD=10
+QUEUE_MONITOR_HEALTH_QUEUED_JOBS_THRESHOLD=1000
+QUEUE_MONITOR_HEALTH_PROCESSING_JOBS_THRESHOLD=100
+QUEUE_MONITOR_HEALTH_STORAGE_MAX_MB=1000
 
 # Metrics Storage (from laravel-queue-metrics)
 QUEUE_METRICS_STORAGE=redis          # redis (default) or database

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -121,6 +121,29 @@ Control how the built-in dashboard loads CSS and JavaScript:
 
 Use `inline` for zero setup, `public` after publishing `queue-monitor-assets`, and `none` when a published/custom dashboard view loads assets from your application's own build. See [Dashboard Assets](dashboard-assets) for the full override workflow.
 
+## Health Checks
+
+Tune health thresholds for your workload:
+
+```php
+'health' => [
+    'stuck_job_minutes' => env('QUEUE_MONITOR_HEALTH_STUCK_JOB_MINUTES', 30),
+    'error_rate_threshold' => env('QUEUE_MONITOR_HEALTH_ERROR_RATE_THRESHOLD', 10.0),
+    'queued_jobs_threshold' => env('QUEUE_MONITOR_HEALTH_QUEUED_JOBS_THRESHOLD', 1000),
+    'processing_jobs_threshold' => env('QUEUE_MONITOR_HEALTH_PROCESSING_JOBS_THRESHOLD', 100),
+    'storage_max_mb' => env('QUEUE_MONITOR_HEALTH_STORAGE_MAX_MB', 1000),
+],
+```
+
+Use the readiness mode before launch:
+
+```bash
+php artisan queue-monitor:health --readiness
+php artisan queue-monitor:health --readiness --json
+```
+
+Readiness checks validate production-sensitive configuration such as access control, API middleware, payload storage, retention limits, and Horizon timeout alignment.
+
 ## Metrics Storage
 
 Queue Monitor depends on [laravel-queue-metrics](https://github.com/cboxdk/laravel-queue-metrics) for per-job CPU and memory instrumentation. Queue-metrics also provides aggregate persistence (worker heartbeats, throughput, baselines), but Queue Monitor doesn't need it.

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -181,11 +181,13 @@ foreach ($health as $queue) {
 ### Top Failing Jobs
 
 ```php
-use Illuminate\Support\Facades\DB;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 
-$topFailures = DB::table('queue_monitor_jobs')
-    ->select('job_class', DB::raw('COUNT(*) as failure_count'))
-    ->where('status', 'failed')
+$topFailures = JobMonitor::query()
+    ->select('job_class')
+    ->selectRaw('COUNT(*) as failure_count')
+    ->where('status', JobStatus::FAILED->value)
     ->whereDate('completed_at', '>=', now()->subDays(7))
     ->groupBy('job_class')
     ->orderByDesc('failure_count')
@@ -396,22 +398,20 @@ echo "Deleted {$deleted} old successful jobs\n";
 ### Export Data for Charts
 
 ```php
-use Cbox\LaravelQueueMonitor\Utilities\DatabaseExpressionHelper;
-use Illuminate\Support\Facades\DB;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 
-$hourExpression = DatabaseExpressionHelper::hourBucket('queued_at', DB::connection()->getDriverName());
-
-$hourlyStats = DB::table('queue_monitor_jobs')
-    ->select([
-        DB::raw("{$hourExpression} as hour"),
-        DB::raw('COUNT(*) as total'),
-        DB::raw('SUM(CASE WHEN status = "completed" THEN 1 ELSE 0 END) as completed'),
-        DB::raw('SUM(CASE WHEN status = "failed" THEN 1 ELSE 0 END) as failed'),
-    ])
+$hourlyStats = JobMonitor::query()
     ->whereBetween('queued_at', [now()->subDay(), now()])
-    ->groupBy(DB::raw($hourExpression))
-    ->orderBy(DB::raw($hourExpression))
-    ->get();
+    ->get(['queued_at', 'status'])
+    ->groupBy(fn (JobMonitor $job): string => $job->queued_at->format('Y-m-d H:00'))
+    ->map(fn ($jobs, string $hour): array => [
+        'hour' => $hour,
+        'total' => $jobs->count(),
+        'completed' => $jobs->filter(fn (JobMonitor $job): bool => $job->status === JobStatus::COMPLETED)->count(),
+        'failed' => $jobs->filter(fn (JobMonitor $job): bool => $job->status === JobStatus::FAILED)->count(),
+    ])
+    ->values();
 
 // Return as JSON for chart library
 return response()->json($hourlyStats);

--- a/src/Commands/HealthCheckCommand.php
+++ b/src/Commands/HealthCheckCommand.php
@@ -12,6 +12,7 @@ class HealthCheckCommand extends Command
 {
     public $signature = 'queue-monitor:health
                         {--alerts : Show only active alerts}
+                        {--readiness : Check production readiness configuration}
                         {--json : Output as JSON}';
 
     public $description = 'Check queue monitor system health';
@@ -20,6 +21,21 @@ class HealthCheckCommand extends Command
     {
         if ($this->option('alerts')) {
             return $this->showAlerts($alerting);
+        }
+
+        if ($this->option('readiness')) {
+            $readiness = $healthCheck->readiness();
+
+            if ($this->option('json')) {
+                $json = json_encode($readiness, JSON_PRETTY_PRINT);
+                $this->line($json !== false ? $json : '{}');
+
+                return self::SUCCESS;
+            }
+
+            $this->displayReadinessStatus($readiness);
+
+            return $readiness['status'] === 'ready' ? self::SUCCESS : self::FAILURE;
         }
 
         $health = $healthCheck->check();
@@ -58,6 +74,33 @@ class HealthCheckCommand extends Command
             $message = $check['message'];
             $rows[] = [
                 $icon,
+                ucwords(str_replace('_', ' ', $name)),
+                $message,
+            ];
+        }
+
+        $this->table(['Status', 'Check', 'Details'], $rows);
+    }
+
+    /**
+     * Display readiness status in table format
+     *
+     * @param  array{status: string, checks: array<string, array<string, mixed>>}  $readiness
+     */
+    private function displayReadinessStatus(array $readiness): void
+    {
+        $this->info('Production Readiness: '.strtoupper($readiness['status']));
+        $this->newLine();
+
+        $rows = [];
+
+        foreach ($readiness['checks'] as $name => $check) {
+            /** @var bool $isHealthy */
+            $isHealthy = $check['healthy'];
+            /** @var string $message */
+            $message = $check['message'];
+            $rows[] = [
+                $isHealthy ? 'OK' : 'ACTION',
                 ucwords(str_replace('_', ' ', $name)),
                 $message,
             ];

--- a/src/LaravelQueueMonitor.php
+++ b/src/LaravelQueueMonitor.php
@@ -54,6 +54,14 @@ final class LaravelQueueMonitor
     }
 
     /**
+     * Determine whether an explicit authorization callback has been registered.
+     */
+    public static function hasAuthCallback(): bool
+    {
+        return self::$authUsing !== null;
+    }
+
+    /**
      * Check if the given request is authorized.
      */
     public static function check(Request $request): bool

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMonitor\Services;
 
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
 use Illuminate\Support\Facades\Cache;
@@ -52,6 +53,30 @@ final class HealthCheckService
         }
 
         return $result;
+    }
+
+    /**
+     * Check production readiness configuration.
+     *
+     * @return array{status: string, checks: array<string, array<string, mixed>>, timestamp: string}
+     */
+    public function readiness(): array
+    {
+        $checks = [
+            'access_control' => $this->checkAccessControlReadiness(),
+            'api_middleware' => $this->checkApiMiddlewareReadiness(),
+            'payload_storage' => $this->checkPayloadStorageReadiness(),
+            'retention' => $this->checkRetentionReadiness(),
+            'horizon_timeouts' => $this->checkHorizonTimeoutReadiness(),
+        ];
+
+        $ready = collect($checks)->every(fn (array $check): bool => (bool) $check['healthy']);
+
+        return [
+            'status' => $ready ? 'ready' : 'attention',
+            'checks' => $checks,
+            'timestamp' => now()->toIso8601String(),
+        ];
     }
 
     /**
@@ -111,7 +136,9 @@ final class HealthCheckService
      */
     private function checkStuckJobs(): array
     {
-        $stuckJobs = QueryBuilderHelper::stuck(30)
+        $thresholdMinutes = $this->intConfig('queue-monitor.health.stuck_job_minutes', 30);
+
+        $stuckJobs = QueryBuilderHelper::stuck($thresholdMinutes)
             ->select(['uuid', 'job_class', 'queue', 'server_name', 'started_at', 'attempt'])
             ->limit(10)
             ->get();
@@ -126,7 +153,7 @@ final class HealthCheckService
                 : 'No stuck jobs detected',
             'details' => [
                 'stuck_count' => $stuck,
-                'threshold_minutes' => 30,
+                'threshold_minutes' => $thresholdMinutes,
                 'stuck_jobs' => $stuckJobs->map(fn ($job) => [
                     'uuid' => $job->uuid,
                     'job_class' => $job->job_class,
@@ -146,13 +173,14 @@ final class HealthCheckService
      */
     private function checkErrorRate(): array
     {
+        $threshold = $this->floatConfig('queue-monitor.health.error_rate_threshold', 10.0);
         $recentTotal = QueryBuilderHelper::lastHours(1)->count();
         $recentFailed = QueryBuilderHelper::lastHours(1)
             ->whereIn('status', [JobStatus::FAILED->value, JobStatus::TIMEOUT->value])
             ->count();
 
         $errorRate = $recentTotal > 0 ? ($recentFailed / $recentTotal) * 100 : 0;
-        $healthy = $errorRate < 10; // < 10% error rate
+        $healthy = $errorRate < $threshold;
 
         return [
             'healthy' => $healthy,
@@ -161,7 +189,7 @@ final class HealthCheckService
                 'error_rate' => round($errorRate, 2),
                 'total_jobs' => $recentTotal,
                 'failed_jobs' => $recentFailed,
-                'threshold' => 10.0,
+                'threshold' => $threshold,
             ],
         ];
     }
@@ -173,10 +201,12 @@ final class HealthCheckService
      */
     private function checkQueueBacklog(): array
     {
+        $queuedThreshold = $this->intConfig('queue-monitor.health.queued_jobs_threshold', 1000);
+        $processingThreshold = $this->intConfig('queue-monitor.health.processing_jobs_threshold', 100);
         $processing = JobMonitor::where('status', JobStatus::PROCESSING)->count();
         $queued = JobMonitor::where('status', JobStatus::QUEUED)->count();
 
-        $healthy = $queued < 1000 && $processing < 100;
+        $healthy = $queued < $queuedThreshold && $processing < $processingThreshold;
 
         return [
             'healthy' => $healthy,
@@ -185,6 +215,8 @@ final class HealthCheckService
                 'queued' => $queued,
                 'processing' => $processing,
                 'total_pending' => $queued + $processing,
+                'queued_threshold' => $queuedThreshold,
+                'processing_threshold' => $processingThreshold,
             ],
         ];
     }
@@ -198,9 +230,25 @@ final class HealthCheckService
     {
         /** @var string $prefix */
         $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
+        /** @var string|null $connection */
+        $connection = config('queue-monitor.database.connection');
+        $maxMb = $this->floatConfig('queue-monitor.health.storage_max_mb', 1000.0);
 
         try {
-            $tableSize = DB::select(
+            $database = DB::connection($connection);
+
+            if (! in_array($database->getDriverName(), ['mysql', 'mariadb'], true)) {
+                return [
+                    'healthy' => true,
+                    'message' => 'Storage check not available for this database driver',
+                    'details' => [
+                        'connection' => $connection ?? 'default',
+                        'driver' => $database->getDriverName(),
+                    ],
+                ];
+            }
+
+            $tableSize = $database->select(
                 'SELECT
                     ROUND((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024, 2) as size_mb,
                     TABLE_ROWS as row_count
@@ -220,7 +268,7 @@ final class HealthCheckService
             $sizeMb = $tableSize[0]->size_mb ?? 0;
             $rows = $tableSize[0]->row_count ?? 0;
 
-            $healthy = $sizeMb < 1000; // < 1GB
+            $healthy = $sizeMb < $maxMb;
 
             return [
                 'healthy' => $healthy,
@@ -228,7 +276,8 @@ final class HealthCheckService
                 'details' => [
                     'size_mb' => $sizeMb,
                     'row_count' => $rows,
-                    'threshold_mb' => 1000,
+                    'threshold_mb' => $maxMb,
+                    'connection' => $connection ?? 'default',
                 ],
             ];
         } catch (\Throwable $e) {
@@ -259,5 +308,241 @@ final class HealthCheckService
     public function isHealthy(): bool
     {
         return $this->check()['status'] === 'healthy';
+    }
+
+    /**
+     * @return array{healthy: bool, message: string, details?: array<string, mixed>}
+     */
+    private function checkAccessControlReadiness(): array
+    {
+        if (app()->environment('local')) {
+            return [
+                'healthy' => true,
+                'message' => 'Local environment uses the built-in local-only access fallback',
+            ];
+        }
+
+        $surfaceEnabled = (bool) config('queue-monitor.ui.enabled', true)
+            || (bool) config('queue-monitor.api.enabled', app()->environment('local'));
+
+        if (! $surfaceEnabled) {
+            return [
+                'healthy' => true,
+                'message' => 'Dashboard and API surfaces are disabled',
+            ];
+        }
+
+        $hasCallback = LaravelQueueMonitor::hasAuthCallback();
+
+        return [
+            'healthy' => $hasCallback,
+            'message' => $hasCallback
+                ? 'Explicit authorization callback registered'
+                : 'Register LaravelQueueMonitor::auth(...) before exposing Queue Monitor outside local',
+        ];
+    }
+
+    /**
+     * @return array{healthy: bool, message: string, details?: array<string, mixed>}
+     */
+    private function checkApiMiddlewareReadiness(): array
+    {
+        $apiEnabled = (bool) config('queue-monitor.api.enabled', app()->environment('local'));
+
+        if (! $apiEnabled) {
+            return [
+                'healthy' => true,
+                'message' => 'API routes are disabled',
+            ];
+        }
+
+        if (app()->environment('local')) {
+            return [
+                'healthy' => true,
+                'message' => 'API is enabled for local development',
+            ];
+        }
+
+        $middleware = $this->middlewareList(config('queue-monitor.api.middleware', []));
+        $hasProtectiveMiddleware = collect($middleware)
+            ->contains(fn (string $entry): bool => str_starts_with($entry, 'auth')
+                || str_starts_with($entry, 'can:')
+                || str_contains($entry, 'Authenticate'));
+
+        return [
+            'healthy' => $hasProtectiveMiddleware,
+            'message' => $hasProtectiveMiddleware
+                ? 'API middleware includes an authentication or authorization layer'
+                : 'Add auth middleware before enabling the API outside local',
+            'details' => [
+                'middleware' => $middleware,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{healthy: bool, message: string, details?: array<string, mixed>}
+     */
+    private function checkPayloadStorageReadiness(): array
+    {
+        $storePayload = (bool) config('queue-monitor.storage.store_payload', app()->environment('local'));
+
+        if (app()->environment('local') || ! $storePayload) {
+            return [
+                'healthy' => true,
+                'message' => $storePayload
+                    ? 'Payload storage is enabled for local development'
+                    : 'Payload storage is disabled outside local',
+            ];
+        }
+
+        return [
+            'healthy' => false,
+            'message' => 'Payload storage is enabled outside local; confirm this is required for replay and acceptable for stored data',
+        ];
+    }
+
+    /**
+     * @return array{healthy: bool, message: string, details?: array<string, mixed>}
+     */
+    private function checkRetentionReadiness(): array
+    {
+        $days = config('queue-monitor.retention.days');
+        $maxRows = config('queue-monitor.retention.max_rows');
+
+        $hasLimit = (is_numeric($days) && (int) $days > 0) || (is_numeric($maxRows) && (int) $maxRows > 0);
+
+        return [
+            'healthy' => $hasLimit,
+            'message' => $hasLimit
+                ? 'Retention limits are configured; schedule queue-monitor:prune in production'
+                : 'Configure a retention day or row limit before production use',
+            'details' => [
+                'days' => $days,
+                'max_rows' => $maxRows,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{healthy: bool, message: string, details?: array<string, mixed>}
+     */
+    private function checkHorizonTimeoutReadiness(): array
+    {
+        $timeouts = $this->horizonTimeouts();
+        $retryAfterValues = $this->queueRetryAfterValues();
+
+        if ($timeouts === [] || $retryAfterValues === []) {
+            return [
+                'healthy' => true,
+                'message' => 'No Horizon timeout and queue retry_after pair found to validate',
+                'details' => [
+                    'horizon_timeouts' => $timeouts,
+                    'queue_retry_after' => $retryAfterValues,
+                ],
+            ];
+        }
+
+        $maxTimeout = max($timeouts);
+        $minRetryAfter = min($retryAfterValues);
+        $healthy = $maxTimeout < $minRetryAfter;
+
+        return [
+            'healthy' => $healthy,
+            'message' => $healthy
+                ? 'Horizon timeout values are lower than queue retry_after values'
+                : 'Horizon timeout must be lower than queue retry_after to avoid duplicate processing',
+            'details' => [
+                'max_horizon_timeout' => $maxTimeout,
+                'min_queue_retry_after' => $minRetryAfter,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function horizonTimeouts(): array
+    {
+        $timeouts = [];
+        $this->collectTimeouts(config('horizon.defaults', []), $timeouts);
+        $this->collectTimeouts(config('horizon.environments', []), $timeouts);
+
+        return array_values(array_unique($timeouts));
+    }
+
+    /**
+     * @param  array<int, int>  $timeouts
+     */
+    private function collectTimeouts(mixed $value, array &$timeouts): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        foreach ($value as $key => $item) {
+            if ($key === 'timeout' && is_numeric($item)) {
+                $timeouts[] = (int) $item;
+
+                continue;
+            }
+
+            $this->collectTimeouts($item, $timeouts);
+        }
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function queueRetryAfterValues(): array
+    {
+        $connections = config('queue.connections', []);
+
+        if (! is_array($connections)) {
+            return [];
+        }
+
+        $values = [];
+
+        foreach ($connections as $connection) {
+            if (is_array($connection) && isset($connection['retry_after']) && is_numeric($connection['retry_after'])) {
+                $values[] = (int) $connection['retry_after'];
+            }
+        }
+
+        return array_values(array_unique($values));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function middlewareList(mixed $middleware): array
+    {
+        if (is_string($middleware)) {
+            return [$middleware];
+        }
+
+        if (! is_array($middleware)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(fn (mixed $entry): string => is_string($entry) ? $entry : '', $middleware),
+            fn (string $entry): bool => $entry !== ''
+        ));
+    }
+
+    private function intConfig(string $key, int $default): int
+    {
+        $value = config($key, $default);
+
+        return is_numeric($value) ? (int) $value : $default;
+    }
+
+    private function floatConfig(string $key, float $default): float
+    {
+        $value = config($key, $default);
+
+        return is_numeric($value) ? (float) $value : $default;
     }
 }

--- a/tests/Feature/Commands/HealthCheckCommandTest.php
+++ b/tests/Feature/Commands/HealthCheckCommandTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Illuminate\Support\Facades\Artisan;
 
 test('health check command displays status', function () {
     JobMonitor::factory()->count(5)->create();
@@ -35,4 +37,40 @@ test('health check command fails when system degraded', function () {
     // Command should fail (return 1) when degraded
     $this->artisan('queue-monitor:health')
         ->assertFailed();
+});
+
+test('health check command shows readiness output', function () {
+    app()->detectEnvironment(fn (): string => 'local');
+    LaravelQueueMonitor::auth(fn (): bool => true);
+
+    config()->set('queue-monitor.storage.store_payload', false);
+
+    $this->artisan('queue-monitor:health --readiness')
+        ->expectsOutputToContain('Production Readiness')
+        ->assertSuccessful();
+});
+
+test('health check command readiness fails for unsafe production configuration', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    LaravelQueueMonitor::$authUsing = null;
+
+    config()->set('queue-monitor.api.enabled', true);
+    config()->set('queue-monitor.api.middleware', ['api']);
+    config()->set('queue-monitor.storage.store_payload', true);
+
+    $this->artisan('queue-monitor:health --readiness')
+        ->expectsOutputToContain('Production Readiness')
+        ->assertFailed();
+});
+
+test('health check command readiness supports json output', function () {
+    app()->detectEnvironment(fn (): string => 'local');
+    LaravelQueueMonitor::auth(fn (): bool => true);
+
+    $exitCode = Artisan::call('queue-monitor:health', ['--readiness' => true, '--json' => true]);
+    $output = Artisan::output();
+
+    expect($exitCode)->toBe(0);
+    expect($output)->toContain('"status"');
+    expect($output)->toContain('"access_control"');
 });

--- a/tests/Feature/Services/HealthCheckServiceTest.php
+++ b/tests/Feature/Services/HealthCheckServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
 
@@ -68,4 +69,63 @@ test('isHealthy returns correct boolean', function () {
     $service = app(HealthCheckService::class);
 
     expect($service->isHealthy())->toBeTrue();
+});
+
+test('readiness returns production readiness checks', function () {
+    $service = app(HealthCheckService::class);
+    $result = $service->readiness();
+
+    expect($result)->toHaveKeys(['status', 'checks', 'timestamp']);
+    expect($result['checks'])->toHaveKeys([
+        'access_control',
+        'api_middleware',
+        'payload_storage',
+        'retention',
+        'horizon_timeouts',
+    ]);
+});
+
+test('readiness passes for protected production configuration', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    LaravelQueueMonitor::auth(fn (): bool => true);
+
+    config()->set('queue-monitor.api.enabled', true);
+    config()->set('queue-monitor.api.middleware', ['api', 'auth:sanctum']);
+    config()->set('queue-monitor.storage.store_payload', false);
+
+    $service = app(HealthCheckService::class);
+    $result = $service->readiness();
+
+    expect($result['status'])->toBe('ready');
+    expect($result['checks']['access_control']['healthy'])->toBeTrue();
+    expect($result['checks']['api_middleware']['healthy'])->toBeTrue();
+    expect($result['checks']['payload_storage']['healthy'])->toBeTrue();
+});
+
+test('readiness flags missing production authorization callback', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    LaravelQueueMonitor::$authUsing = null;
+
+    config()->set('queue-monitor.api.enabled', false);
+    config()->set('queue-monitor.storage.store_payload', false);
+
+    $service = app(HealthCheckService::class);
+    $result = $service->readiness();
+
+    expect($result['status'])->toBe('attention');
+    expect($result['checks']['access_control']['healthy'])->toBeFalse();
+});
+
+test('readiness flags production payload storage', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    LaravelQueueMonitor::auth(fn (): bool => true);
+
+    config()->set('queue-monitor.api.enabled', false);
+    config()->set('queue-monitor.storage.store_payload', true);
+
+    $service = app(HealthCheckService::class);
+    $result = $service->readiness();
+
+    expect($result['status'])->toBe('attention');
+    expect($result['checks']['payload_storage']['healthy'])->toBeFalse();
 });


### PR DESCRIPTION
## What changed

- Adds `queue-monitor:health --readiness` for launch configuration checks.
- Validates production-sensitive setup: authorization callback, API middleware, payload storage, retention limits, and Horizon timeout alignment.
- Makes health thresholds configurable for stuck jobs, error rate, backlog, processing count, and storage size.
- Ensures storage health probing uses the configured monitor database connection and only runs the MySQL-specific size query on supported drivers.
- Updates docs and examples to use package-aware model queries instead of default-connection or driver-specific SQL snippets.

## Validation

- `composer format`
- `vendor/bin/pest tests/Feature/Commands/HealthCheckCommandTest.php tests/Feature/Services/HealthCheckServiceTest.php tests/Unit/Configuration/QueueMonitorConfigTest.php`
- `composer analyse`
- `composer test` — 487 passed, 1 skipped
- `composer validate --strict`