### PR TITLE
Harden API limits and payload redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to `laravel-queue-monitor` will be documented in this file.
 - Default payload storage to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_STORE_PAYLOAD` is explicitly set.
 - Default REST API route registration to enabled in `local` and disabled outside `local` unless `QUEUE_MONITOR_API_ENABLED` is explicitly set.
 - Add `queue-monitor:health --readiness` for launch configuration checks and make health thresholds configurable.
+- Mask serialized Laravel command payloads in API/dashboard responses by default.
+- Add configurable API, export, and batch-operation limits to keep expensive requests bounded.
 - Expand CI coverage for Laravel 13/PHP 8.5 and dashboard asset builds.
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ return [
         'prune_statuses' => ['completed'],
     ],
 
+    'batch' => [
+        'chunk_size' => env('QUEUE_MONITOR_BATCH_CHUNK_SIZE', 100),
+        'max_jobs' => env('QUEUE_MONITOR_BATCH_MAX_JOBS', 1000),
+    ],
+
     // Web dashboard
     'ui' => [
         'enabled' => true,
@@ -245,6 +250,14 @@ return [
         'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api', 'auth:sanctum'],
+        'default_limit' => env('QUEUE_MONITOR_API_DEFAULT_LIMIT', 50),
+        'max_limit' => env('QUEUE_MONITOR_API_MAX_LIMIT', 1000),
+        'sensitive_keys' => ['password', 'token', 'secret', 'key', 'authorization', 'api_key', 'credit_card', 'cvv', 'ssn', 'private_key', 'command'],
+    ],
+
+    'export' => [
+        'default_limit' => env('QUEUE_MONITOR_EXPORT_DEFAULT_LIMIT', 1000),
+        'max_rows' => env('QUEUE_MONITOR_EXPORT_MAX_ROWS', 5000),
     ],
 ];
 ```
@@ -277,7 +290,7 @@ LaravelQueueMonitor::auth(function ($request) {
 
 ### API Authentication
 
-The REST API exposes job payloads and exception traces. Always add auth middleware in production:
+The REST API exposes job payloads and operational failure data. Always add auth middleware in production:
 
 ```php
 'api' => [
@@ -287,7 +300,7 @@ The REST API exposes job payloads and exception traces. Always add auth middlewa
 
 ### Payload Redaction
 
-The API automatically masks sensitive keys (`password`, `token`, `secret`, etc.). Raw payloads are stored for replay; only API responses are redacted.
+The API automatically masks sensitive keys (`password`, `token`, `secret`, serialized Laravel `command` payloads, etc.). Raw payloads are stored for replay; only API/dashboard responses are redacted.
 
 ## Architecture
 

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -169,6 +169,7 @@ return [
     */
     'batch' => [
         'chunk_size' => env('QUEUE_MONITOR_BATCH_CHUNK_SIZE', 100),
+        'max_jobs' => env('QUEUE_MONITOR_BATCH_MAX_JOBS', 1000),
     ],
 
     /*
@@ -184,10 +185,26 @@ return [
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api'],
         'rate_limit' => '60,1', // 60 requests per minute
+        'default_limit' => env('QUEUE_MONITOR_API_DEFAULT_LIMIT', 50),
+        'max_limit' => env('QUEUE_MONITOR_API_MAX_LIMIT', 1000),
 
         // Keys to mask in the payload response (e.g. password, token, secret)
         // Set to empty array to disable redaction
-        'sensitive_keys' => ['password', 'token', 'secret', 'key', 'authorization', 'api_key', 'credit_card', 'cvv', 'ssn', 'private_key'],
+        'sensitive_keys' => ['password', 'token', 'secret', 'key', 'authorization', 'api_key', 'credit_card', 'cvv', 'ssn', 'private_key', 'command'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Export Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Keep API exports bounded so integrations cannot accidentally load the
+    | entire job table into memory.
+    |
+    */
+    'export' => [
+        'default_limit' => env('QUEUE_MONITOR_EXPORT_DEFAULT_LIMIT', 1000),
+        'max_rows' => env('QUEUE_MONITOR_EXPORT_MAX_ROWS', 5000),
     ],
 
     /*

--- a/docs/advanced/advanced-usage.md
+++ b/docs/advanced/advanced-usage.md
@@ -449,7 +449,7 @@ $filters = new JobFilterData(
         null,
     queues: request('queues'),
     search: request('search'),
-    limit: min(request('limit', 50), 1000)
+    limit: min(request('limit', 50), config('queue-monitor.api.max_limit', 1000))
 );
 
 $jobs = QueueMonitor::getJobs($filters);

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -138,11 +138,25 @@ return [
         'prune_statuses' => ['completed'],
     ],
 
+    // Batch operation limits
+    'batch' => [
+        'chunk_size' => env('QUEUE_MONITOR_BATCH_CHUNK_SIZE', 100),
+        'max_jobs' => env('QUEUE_MONITOR_BATCH_MAX_JOBS', 1000),
+    ],
+
     // REST API settings
     'api' => [
         'enabled' => env('QUEUE_MONITOR_API_ENABLED', env('APP_ENV') === 'local'),
         'prefix' => 'api/queue-monitor',
         'middleware' => ['api'],
+        'default_limit' => env('QUEUE_MONITOR_API_DEFAULT_LIMIT', 50),
+        'max_limit' => env('QUEUE_MONITOR_API_MAX_LIMIT', 1000),
+    ],
+
+    // Export limits
+    'export' => [
+        'default_limit' => env('QUEUE_MONITOR_EXPORT_DEFAULT_LIMIT', 1000),
+        'max_rows' => env('QUEUE_MONITOR_EXPORT_MAX_ROWS', 5000),
     ],
 
     // Web dashboard assets
@@ -173,6 +187,12 @@ return [
 QUEUE_MONITOR_ENABLED=true
 QUEUE_MONITOR_STORE_PAYLOAD=false # defaults true only in local
 QUEUE_MONITOR_API_ENABLED=false   # defaults true only in local
+QUEUE_MONITOR_API_DEFAULT_LIMIT=50
+QUEUE_MONITOR_API_MAX_LIMIT=1000
+QUEUE_MONITOR_EXPORT_DEFAULT_LIMIT=1000
+QUEUE_MONITOR_EXPORT_MAX_ROWS=5000
+QUEUE_MONITOR_BATCH_CHUNK_SIZE=100
+QUEUE_MONITOR_BATCH_MAX_JOBS=1000
 QUEUE_MONITOR_HEALTH_STUCK_JOB_MINUTES=30
 QUEUE_MONITOR_HEALTH_ERROR_RATE_THRESHOLD=10
 QUEUE_MONITOR_HEALTH_QUEUED_JOBS_THRESHOLD=1000

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -75,11 +75,11 @@ Retrieve a paginated list of jobs.
 
 ### 2. Get Job Details
 
-Retrieve full details for a specific job, including payload and exception trace.
+Retrieve full details for a specific job, including the redacted payload and exception summary.
 
 **Endpoint:** `GET /jobs/{uuid}`
 
-**Security Note:** Sensitive keys in the payload (like `password` or `token`) are automatically masked based on the `api.sensitive_keys` configuration.
+**Security Note:** Sensitive keys in the payload (like `password`, `token`, or Laravel's serialized `command` payload) are automatically masked based on the `api.sensitive_keys` configuration.
 
 **Response:**
 
@@ -94,8 +94,7 @@ Retrieve full details for a specific job, including payload and exception trace.
         },
         "exception": {
             "class": "Exception",
-            "message": "Payment failed",
-            "trace": "..."
+            "message": "Payment failed"
         }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ use Cbox\LaravelQueueMonitor\Http\Controllers\StuckJobController;
 use Cbox\LaravelQueueMonitor\Http\Middleware\EnsureQueueMonitorEnabled;
 use Illuminate\Support\Facades\Route;
 
-if (! config('queue-monitor.api.enabled', true)) {
+if (! config('queue-monitor.api.enabled', app()->environment('local'))) {
     return;
 }
 

--- a/src/DataTransferObjects/JobFilterData.php
+++ b/src/DataTransferObjects/JobFilterData.php
@@ -69,8 +69,13 @@ final readonly class JobFilterData
      *
      * @param  array<string, mixed>  $data
      */
-    public static function fromRequest(array $data): self
+    public static function fromRequest(array $data, ?int $maxLimit = null, ?int $defaultLimit = null): self
     {
+        $configuredMaxLimit = $maxLimit ?? self::intConfig('queue-monitor.api.max_limit', 1000);
+        $configuredDefaultLimit = $defaultLimit ?? self::intConfig('queue-monitor.api.default_limit', 50);
+        $maxLimit = max(1, $configuredMaxLimit);
+        $defaultLimit = max(1, min($configuredDefaultLimit, $maxLimit));
+
         return new self(
             statuses: self::parseStatuses($data['statuses'] ?? null),
             queues: isset($data['queues']) && is_array($data['queues'])
@@ -98,7 +103,7 @@ final readonly class JobFilterData
             maxDurationMs: isset($data['max_duration_ms']) && is_numeric($data['max_duration_ms']) ? (int) $data['max_duration_ms'] : null,
             minAttempts: isset($data['min_attempts']) && is_numeric($data['min_attempts']) ? (int) $data['min_attempts'] : null,
             search: isset($data['search']) && is_scalar($data['search']) ? (string) $data['search'] : null,
-            limit: isset($data['limit']) && is_numeric($data['limit']) ? max(1, min((int) $data['limit'], 1000)) : 50,
+            limit: isset($data['limit']) && is_numeric($data['limit']) ? max(1, min((int) $data['limit'], $maxLimit)) : $defaultLimit,
             offset: isset($data['offset']) && is_numeric($data['offset']) ? max(0, (int) $data['offset']) : 0,
             sortBy: self::validateSortColumn($data['sort_by'] ?? null),
             sortDirection: self::validateSortDirection($data['sort_direction'] ?? null),
@@ -199,6 +204,13 @@ final readonly class JobFilterData
         $direction = strtolower((string) $direction);
 
         return in_array($direction, ['asc', 'desc'], true) ? $direction : 'desc';
+    }
+
+    private static function intConfig(string $key, int $default): int
+    {
+        $value = config($key, $default);
+
+        return is_numeric($value) ? (int) $value : $default;
     }
 
     /**

--- a/src/Http/Controllers/BatchOperationsController.php
+++ b/src/Http/Controllers/BatchOperationsController.php
@@ -23,18 +23,20 @@ class BatchOperationsController extends Controller
      */
     public function batchReplay(Request $request): JsonResponse
     {
+        $maxJobsLimit = $this->maxJobsLimit();
+
         $validated = $request->validate([
             'uuids' => 'sometimes|array',
             'uuids.*' => 'string|uuid',
             'filters' => 'sometimes|array',
-            'max_jobs' => 'sometimes|integer|min:1|max:1000',
+            'max_jobs' => 'sometimes|integer|min:1|max:'.$maxJobsLimit,
         ]);
 
         if (isset($validated['uuids'])) {
             $result = $this->batchReplayAction->executeByUuids($validated['uuids']);
         } else {
             $filters = JobFilterData::fromRequest($validated['filters'] ?? []);
-            $maxJobs = $validated['max_jobs'] ?? 100;
+            $maxJobs = $validated['max_jobs'] ?? min(100, $maxJobsLimit);
 
             $result = $this->batchReplayAction->execute($filters, $maxJobs);
         }
@@ -52,18 +54,20 @@ class BatchOperationsController extends Controller
      */
     public function batchDelete(Request $request): JsonResponse
     {
+        $maxJobsLimit = $this->maxJobsLimit();
+
         $validated = $request->validate([
             'uuids' => 'sometimes|array',
             'uuids.*' => 'string|uuid',
             'filters' => 'sometimes|array',
-            'max_jobs' => 'sometimes|integer|min:1|max:1000',
+            'max_jobs' => 'sometimes|integer|min:1|max:'.$maxJobsLimit,
         ]);
 
         if (isset($validated['uuids'])) {
             $result = $this->batchDeleteAction->executeByUuids($validated['uuids']);
         } else {
             $filters = JobFilterData::fromRequest($validated['filters'] ?? []);
-            $maxJobs = $validated['max_jobs'] ?? 1000;
+            $maxJobs = $validated['max_jobs'] ?? $maxJobsLimit;
 
             $result = $this->batchDeleteAction->execute($filters, $maxJobs);
         }
@@ -73,5 +77,12 @@ class BatchOperationsController extends Controller
             'deleted' => $result['deleted'],
             'failed' => $result['failed'],
         ]);
+    }
+
+    private function maxJobsLimit(): int
+    {
+        $value = config('queue-monitor.batch.max_jobs', 1000);
+
+        return is_numeric($value) ? max(1, (int) $value) : 1000;
     }
 }

--- a/src/Http/Controllers/ExportController.php
+++ b/src/Http/Controllers/ExportController.php
@@ -22,7 +22,7 @@ class ExportController extends Controller
      */
     public function csv(Request $request): Response
     {
-        $filters = JobFilterData::fromRequest($request->all());
+        $filters = $this->filtersFromRequest($request);
 
         $csv = $this->exportService->toCsv($filters);
 
@@ -37,7 +37,7 @@ class ExportController extends Controller
      */
     public function json(Request $request): JsonResponse
     {
-        $filters = JobFilterData::fromRequest($request->all());
+        $filters = $this->filtersFromRequest($request);
 
         $data = $this->exportService->toJson($filters);
 
@@ -68,5 +68,20 @@ class ExportController extends Controller
         $report = $this->exportService->failedJobsReport();
 
         return response()->json($report);
+    }
+
+    private function filtersFromRequest(Request $request): JobFilterData
+    {
+        $maxRows = $this->intConfig('queue-monitor.export.max_rows', 5000);
+        $defaultLimit = $this->intConfig('queue-monitor.export.default_limit', 1000);
+
+        return JobFilterData::fromRequest($request->all(), $maxRows, $defaultLimit);
+    }
+
+    private function intConfig(string $key, int $default): int
+    {
+        $value = config($key, $default);
+
+        return is_numeric($value) ? max(1, (int) $value) : $default;
     }
 }

--- a/src/Http/Controllers/JobMonitorController.php
+++ b/src/Http/Controllers/JobMonitorController.php
@@ -84,8 +84,7 @@ class JobMonitorController extends Controller
      */
     public function failed(Request $request): JobMonitorCollection
     {
-        $limitValue = $request->input('limit', 100);
-        $limit = is_numeric($limitValue) ? min(max((int) $limitValue, 1), 1000) : 100;
+        $limit = $this->boundedLimit($request->input('limit'), 100);
 
         $jobs = $this->repository->getFailedJobs($limit);
 
@@ -97,11 +96,18 @@ class JobMonitorController extends Controller
      */
     public function recent(Request $request): JobMonitorCollection
     {
-        $limitValue = $request->input('limit', 100);
-        $limit = is_numeric($limitValue) ? min(max((int) $limitValue, 1), 1000) : 100;
+        $limit = $this->boundedLimit($request->input('limit'), 100);
 
         $jobs = $this->repository->getRecentJobs($limit);
 
         return new JobMonitorCollection($jobs);
+    }
+
+    private function boundedLimit(mixed $value, int $default): int
+    {
+        $maxLimit = config('queue-monitor.api.max_limit', 1000);
+        $maxLimit = is_numeric($maxLimit) ? max(1, (int) $maxLimit) : 1000;
+
+        return is_numeric($value) ? min(max((int) $value, 1), $maxLimit) : min($default, $maxLimit);
     }
 }

--- a/src/Http/Requests/ListJobsRequest.php
+++ b/src/Http/Requests/ListJobsRequest.php
@@ -49,7 +49,7 @@ class ListJobsRequest extends FormRequest
             'max_duration_ms' => 'sometimes|integer|min:0',
             'min_attempts' => 'sometimes|integer|min:1',
             'search' => 'sometimes|string|max:255',
-            'limit' => 'sometimes|integer|min:1|max:1000',
+            'limit' => 'sometimes|integer|min:1|max:'.$this->maxLimit(),
             'offset' => 'sometimes|integer|min:0',
             'sort_by' => 'sometimes|string|in:queued_at,started_at,completed_at,duration_ms,created_at',
             'sort_direction' => 'sometimes|string|in:asc,desc',
@@ -66,8 +66,15 @@ class ListJobsRequest extends FormRequest
         return [
             'statuses.*.in' => 'Invalid job status. Must be one of: '.implode(', ', JobStatus::values()),
             'worker_type.in' => 'Invalid worker type. Must be one of: '.implode(', ', WorkerType::values()),
-            'limit.max' => 'Maximum limit is 1000 jobs per request',
+            'limit.max' => 'Maximum limit is '.$this->maxLimit().' jobs per request',
             'sort_by.in' => 'Invalid sort field. Must be one of: queued_at, started_at, completed_at, duration_ms, created_at',
         ];
+    }
+
+    private function maxLimit(): int
+    {
+        $value = config('queue-monitor.api.max_limit', 1000);
+
+        return is_numeric($value) ? max(1, (int) $value) : 1000;
     }
 }

--- a/src/Utilities/PayloadRedactor.php
+++ b/src/Utilities/PayloadRedactor.php
@@ -20,14 +20,16 @@ class PayloadRedactor
         }
 
         foreach ($payload as $key => $value) {
-            if (is_array($value)) {
-                $payload[$key] = self::redact($value, $sensitiveKeys);
+            if (is_string($key) && self::isSensitive($key, $sensitiveKeys)) {
+                $payload[$key] = '*****';
 
                 continue;
             }
 
-            if (is_string($key) && self::isSensitive($key, $sensitiveKeys)) {
-                $payload[$key] = '*****';
+            if (is_array($value)) {
+                $payload[$key] = self::redact($value, $sensitiveKeys);
+
+                continue;
             }
         }
 

--- a/tests/Feature/Api/BatchOperationsApiTest.php
+++ b/tests/Feature/Api/BatchOperationsApiTest.php
@@ -76,6 +76,23 @@ test('batch delete with filters deletes matching jobs', function () {
     expect(JobMonitor::count())->toBe(2);
 });
 
+test('batch operations validate max jobs against configured limit', function () {
+    config()->set('queue-monitor.batch.max_jobs', 2);
+
+    $replayResponse = postJson('/api/queue-monitor/batch/replay', [
+        'filters' => ['statuses' => ['failed']],
+        'max_jobs' => 3,
+    ]);
+
+    $deleteResponse = postJson('/api/queue-monitor/batch/delete', [
+        'filters' => ['statuses' => ['completed']],
+        'max_jobs' => 3,
+    ]);
+
+    $replayResponse->assertStatus(422);
+    $deleteResponse->assertStatus(422);
+});
+
 test('batch replay validates uuid format', function () {
     $response = postJson('/api/queue-monitor/batch/replay', [
         'uuids' => ['not-a-uuid'],

--- a/tests/Feature/Api/ExportApiTest.php
+++ b/tests/Feature/Api/ExportApiTest.php
@@ -72,3 +72,20 @@ test('export csv respects filters', function () {
 
     expect(substr_count($content, "\n"))->toBe(6); // Header + 5 jobs
 });
+
+test('export endpoints clamp requested rows to configured maximum', function () {
+    config()->set('queue-monitor.export.max_rows', 3);
+    config()->set('queue-monitor.export.default_limit', 3);
+
+    JobMonitor::factory()->count(5)->create();
+
+    $csvResponse = $this->get('/api/queue-monitor/export/csv?limit=100');
+    $jsonResponse = $this->getJson('/api/queue-monitor/export/json?limit=100');
+
+    $csvResponse->assertOk();
+    $jsonResponse->assertOk();
+
+    expect(substr_count($csvResponse->getContent(), "\n"))->toBe(4);
+    expect($jsonResponse->json('data'))->toHaveCount(3);
+    expect($jsonResponse->json('meta.count'))->toBe(3);
+});

--- a/tests/Feature/Api/JobMonitorApiTest.php
+++ b/tests/Feature/Api/JobMonitorApiTest.php
@@ -51,6 +51,25 @@ test('can get job details via api', function () {
         ]);
 });
 
+test('job details redacts stored command payload via api', function () {
+    config(['queue-monitor.api.sensitive_keys' => ['command']]);
+
+    $this->job->update([
+        'payload' => [
+            'data' => [
+                'commandName' => 'App\\Jobs\\SensitiveJob',
+                'command' => 'O:22:"App\\Jobs\\SensitiveJob":1:{s:8:"password";s:9:"secret123";}',
+            ],
+        ],
+    ]);
+
+    $response = $this->getJson("/api/queue-monitor/jobs/{$this->job->uuid}");
+
+    $response->assertOk()
+        ->assertJsonPath('data.payload.data.commandName', '*****')
+        ->assertJsonPath('data.payload.data.command', '*****');
+});
+
 test('can filter jobs by status', function () {
     JobMonitor::create([
         'uuid' => Str::uuid()->toString(),

--- a/tests/Feature/Api/JobMonitorFailedRecentApiTest.php
+++ b/tests/Feature/Api/JobMonitorFailedRecentApiTest.php
@@ -48,15 +48,16 @@ test('recent endpoint respects limit parameter', function () {
     expect($data)->toHaveCount(4);
 });
 
-test('failed endpoint clamps limit to maximum of 1000', function () {
+test('failed endpoint clamps limit to configured maximum', function () {
+    config()->set('queue-monitor.api.max_limit', 2);
+
     JobMonitor::factory()->count(3)->failed()->create();
 
-    // Absurdly high limit should not cause issues — clamped to 1000
     $response = getJson('/api/queue-monitor/jobs/failed?limit=999999');
 
     $response->assertOk();
     $data = $response->json('data');
-    expect($data)->toHaveCount(3);
+    expect($data)->toHaveCount(2);
 });
 
 test('recent endpoint clamps limit to minimum of 1', function () {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -32,18 +32,24 @@ it('returns metrics for the dashboard', function () {
 });
 
 it('redacts sensitive data in dashboard payload', function () {
-    config(['queue-monitor.api.sensitive_keys' => ['password']]);
+    config(['queue-monitor.api.sensitive_keys' => ['password', 'command']]);
 
     $job = JobMonitor::factory()->create([
         'payload' => [
             'user' => 'test',
             'password' => 'secret123',
+            'data' => [
+                'commandName' => 'App\\Jobs\\SensitiveJob',
+                'command' => 'O:22:"App\\Jobs\\SensitiveJob":1:{s:8:"password";s:9:"secret123";}',
+            ],
         ],
     ]);
 
     getJson(config('queue-monitor.ui.route_prefix')."/jobs/{$job->uuid}/payload")
         ->assertStatus(200)
         ->assertJsonPath('payload.password', '*****')
+        ->assertJsonPath('payload.data.commandName', '*****')
+        ->assertJsonPath('payload.data.command', '*****')
         ->assertJsonPath('payload.user', 'test');
 });
 

--- a/tests/Unit/Configuration/QueueMonitorConfigTest.php
+++ b/tests/Unit/Configuration/QueueMonitorConfigTest.php
@@ -112,3 +112,20 @@ test('explicit api env disables api in local environments', function () {
 
     expect($config['api']['enabled'])->toBeFalse();
 });
+
+test('api response redaction masks serialized commands by default', function () {
+    $config = queueMonitorConfigWithEnv('local');
+
+    expect($config['api']['sensitive_keys'])->toContain('command');
+});
+
+test('api and export limits have safe defaults', function () {
+    $config = queueMonitorConfigWithEnv('local');
+
+    expect($config['api']['default_limit'])->toBe(50);
+    expect($config['api']['max_limit'])->toBe(1000);
+    expect($config['export']['default_limit'])->toBe(1000);
+    expect($config['export']['max_rows'])->toBe(5000);
+    expect($config['batch']['chunk_size'])->toBe(100);
+    expect($config['batch']['max_jobs'])->toBe(1000);
+});

--- a/tests/Unit/Utilities/PayloadRedactorTest.php
+++ b/tests/Unit/Utilities/PayloadRedactorTest.php
@@ -105,3 +105,20 @@ test('handles deeply nested structures', function () {
     expect($result['level1']['level2']['level3']['secret'])->toBe('*****');
     expect($result['level1']['level2']['level3']['safe'])->toBe('visible');
 });
+
+test('redacts sensitive array values before traversing nested payloads', function () {
+    $payload = [
+        'data' => [
+            'commandName' => 'App\\Jobs\\ImportUsers',
+            'command' => [
+                'public' => 'visible',
+                'password' => 'secret',
+            ],
+        ],
+    ];
+
+    $result = PayloadRedactor::redact($payload, ['command', 'password']);
+
+    expect($result['data']['commandName'])->toBe('*****');
+    expect($result['data']['command'])->toBe('*****');
+});


### PR DESCRIPTION
## Summary
- mask serialized Laravel command payloads in API and dashboard responses by default
- add configurable API, export, and batch operation limits
- align docs and regression coverage for production defaults and bounded requests

## Validation
- composer format
- ./vendor/bin/pest tests/Unit/Utilities/PayloadRedactorTest.php tests/Feature/DashboardTest.php tests/Feature/Api/JobMonitorApiTest.php tests/Feature/Api/JobMonitorFailedRecentApiTest.php tests/Feature/Api/ExportApiTest.php tests/Feature/Api/BatchOperationsApiTest.php tests/Unit/Configuration/QueueMonitorConfigTest.php
- composer analyse
- composer test
- composer validate --strict