### PR TITLE
Change .qm-sidebar height to min-height

### DIFF
--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -69,7 +69,7 @@
             gap: 22px;
             position: sticky;
             top: 0;
-            height: 100vh;
+            min-height: 100vh;
             z-index: 50;
             transition: transform 0.22s ease;
         }

--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -58,6 +58,9 @@
             display: grid;
             grid-template-columns: 248px minmax(0, 1fr);
             min-height: 100vh;
+            /* Keep the sidebar column dark for the full page height even when
+               the page is taller than the viewport. */
+            background: linear-gradient(to right, #101722 248px, transparent 248px);
         }
 
         .qm-sidebar {
@@ -69,7 +72,8 @@
             gap: 22px;
             position: sticky;
             top: 0;
-            min-height: 100vh;
+            height: 100vh;
+            overflow-y: auto;
             z-index: 50;
             transition: transform 0.22s ease;
         }
@@ -905,6 +909,7 @@
         @media (max-width: 900px) {
             .qm-app {
                 grid-template-columns: 1fr;
+                background: none;
             }
 
             .qm-menu-button {


### PR DESCRIPTION
 Without this the nav menu is stuck at 100 vh, so when the content is larger, ie like the below screenshot it looks weird:
 
<img width="1861" height="394" alt="Screenshot 2026-08-25 at 10 25 05" src="https://github.com/user-attachments/assets/502de375-15f1-4b09-aed0-dd55bdcd327e" />

(I'd expect the menu to be follow the content height basically)