### PR TITLE
fix(health): honour connection table prefix in storage check; surface prefix and publish docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ php artisan migrate
 
 > **Performance note:** The database driver is for low-scale workloads (< 10 workers). At higher scale, metrics writes compete with your queue jobs for database connections. Set `QUEUE_METRICS_MAX_SAMPLES=500` to keep table sizes manageable. See the [laravel-queue-metrics docs](https://github.com/cboxdk/laravel-queue-metrics) for details.
 
+### Optional: Publish migrations for customization
+
+```bash
+php artisan vendor:publish --tag="queue-monitor-migrations"
+```
+
+If you publish the migrations, also set `QUEUE_MONITOR_ENABLE_MIGRATIONS=false` so the vendor copies stop registering. Otherwise both the vendor migration and the published copy run, and a `migrate:rollback` of the published copy will drop the live queue-monitor tables.
+
 ### Optional: Publish views for customization
 
 ```bash

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -58,7 +58,7 @@ return [
     */
     'database' => [
         'connection' => env('QUEUE_MONITOR_DB_CONNECTION'),
-        'table_prefix' => 'queue_monitor_',
+        'table_prefix' => env('QUEUE_MONITOR_TABLE_PREFIX', 'queue_monitor_'),
     ],
 
     /*

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,7 +90,7 @@ Publish migrations for customization:
 php artisan vendor:publish --tag="queue-monitor-migrations"
 ```
 
-If you publish and manage the migrations yourself (for example to run them with a dedicated database user), disable the package's automatic migration loading by setting `QUEUE_MONITOR_ENABLE_MIGRATIONS=false` (config key `enable_migrations`). Publishing keeps working with the flag disabled.
+If you publish and manage the migrations yourself (for example to run them with a dedicated database user), disable the package's automatic migration loading by setting `QUEUE_MONITOR_ENABLE_MIGRATIONS=false` (config key `enable_migrations`). Publishing keeps working with the flag disabled. Do not leave the flag enabled after publishing: the vendor migration and the published copy register under different migration names, so both run — and a later `migrate:rollback` of the published copy will drop the live queue-monitor tables. Always set `QUEUE_MONITOR_ENABLE_MIGRATIONS=false` when you publish the migrations.
 
 Publish views for customization:
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -13,11 +13,13 @@ Configure which database connection to use for monitoring data:
 ```php
 'database' => [
     'connection' => env('QUEUE_MONITOR_DB_CONNECTION'),
-    'table_prefix' => 'queue_monitor_',
+    'table_prefix' => env('QUEUE_MONITOR_TABLE_PREFIX', 'queue_monitor_'),
 ],
 ```
 
 This allows you to store monitoring data separately from your application data if desired.
+
+`table_prefix` is prepended to every table the package creates (`queue_monitor_jobs`, `queue_monitor_tags`, `queue_monitor_scaling_events`, `queue_monitor_cluster_events`). Change it only when the default names collide with existing tables or your naming conventions require something else. Set it **before** running the package migrations — the prefix is baked into the physical table names at migration time. Changing it after installation requires manually renaming the existing tables to match; the package does not rename tables or migrate data for you.
 
 Dashboard analytics generate database-specific SQL for timestamp bucketing and queue pickup latency. The package supports MySQL/MariaDB, PostgreSQL, SQL Server, and SQLite for those expressions.
 

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -8,6 +8,7 @@ use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
+use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -228,8 +229,6 @@ final class HealthCheckService
      */
     private function checkStorage(): array
     {
-        /** @var string $prefix */
-        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
         /** @var string|null $connection */
         $connection = config('queue-monitor.database.connection');
         $maxMb = $this->floatConfig('queue-monitor.health.storage_max_mb', 1000.0);
@@ -255,7 +254,7 @@ final class HealthCheckService
                 FROM information_schema.TABLES
                 WHERE TABLE_NAME = ?
                 AND TABLE_SCHEMA = DATABASE()',
-                [$prefix.'jobs']
+                [$this->monitorJobsTable($database)]
             );
 
             if (empty($tableSize)) {
@@ -286,6 +285,22 @@ final class HealthCheckService
                 'message' => 'Storage check not available',
             ];
         }
+    }
+
+    /**
+     * Resolve the physical name of the monitor jobs table on a connection.
+     *
+     * Schema and query builders apply the connection's own table prefix
+     * (database.connections.*.prefix) automatically, but raw lookups against
+     * information_schema do not — so it must be prepended to the package's
+     * configured table prefix here.
+     */
+    public function monitorJobsTable(Connection $database): string
+    {
+        /** @var string $prefix */
+        $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
+
+        return $database->getTablePrefix().$prefix.'jobs';
     }
 
     /**

--- a/tests/Feature/Services/HealthCheckServiceTest.php
+++ b/tests/Feature/Services/HealthCheckServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
+use Illuminate\Support\Facades\DB;
 
 test('health check returns comprehensive status', function () {
     JobMonitor::factory()->count(10)->create();
@@ -69,6 +70,32 @@ test('isHealthy returns correct boolean', function () {
     $service = app(HealthCheckService::class);
 
     expect($service->isHealthy())->toBeTrue();
+});
+
+test('storage check table lookup includes the connection table prefix', function () {
+    config()->set('database.connections.prefixed', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => 'app_',
+    ]);
+
+    $service = app(HealthCheckService::class);
+
+    expect($service->monitorJobsTable(DB::connection('prefixed')))->toBe('app_queue_monitor_jobs');
+    expect($service->monitorJobsTable(DB::connection('testing')))->toBe('queue_monitor_jobs');
+});
+
+test('storage check table lookup combines connection and package prefixes', function () {
+    config()->set('database.connections.prefixed', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => 'app_',
+    ]);
+    config()->set('queue-monitor.database.table_prefix', 'qm_');
+
+    $service = app(HealthCheckService::class);
+
+    expect($service->monitorJobsTable(DB::connection('prefixed')))->toBe('app_qm_jobs');
 });
 
 test('readiness returns production readiness checks', function () {

--- a/tests/Feature/TablePrefixTest.php
+++ b/tests/Feature/TablePrefixTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Tests\Feature;
+
+use Cbox\LaravelQueueMonitor\Models\ClusterEvent;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Models\ScalingEvent;
+use Cbox\LaravelQueueMonitor\Models\Tag;
+use Cbox\LaravelQueueMonitor\Tests\TestCase;
+
+class TablePrefixTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        config()->set('queue-monitor.database.table_prefix', 'custom_monitor_');
+    }
+
+    public function test_models_resolve_table_names_from_configured_prefix(): void
+    {
+        $this->assertSame('custom_monitor_jobs', (new JobMonitor)->getTable());
+        $this->assertSame('custom_monitor_tags', (new Tag)->getTable());
+        $this->assertSame('custom_monitor_scaling_events', (new ScalingEvent)->getTable());
+        $this->assertSame('custom_monitor_cluster_events', (new ClusterEvent)->getTable());
+    }
+}


### PR DESCRIPTION
Follow-ups from the migrations/table-prefix assessment:

- **Real bug fix:** the storage health check queried `information_schema.TABLES` with only the package's `table_prefix`. Hosts using a Laravel connection-level prefix (`database.connections.*.prefix`) always got a false "not available", because raw information_schema lookups don't apply the connection prefix the way Schema/query builders do. Name resolution now lives in `monitorJobsTable()` combining both prefixes, covered by tests on a prefixed connection.
- `table_prefix` is now env-overridable via `QUEUE_MONITOR_TABLE_PREFIX`, matching the rest of the config file.
- Docs: when/how to change the prefix (before migrations; manual rename afterwards), and a warning that publishing migrations without setting `QUEUE_MONITOR_ENABLE_MIGRATIONS=false` leaves both migration copies registered — a rollback of the published copy would drop live tables.
- README now mentions the `queue-monitor-migrations` publish tag alongside the other tags.
- Regression test: all four models resolve their table names from a non-default package prefix (previously only the default was tested).

Gates: pint, PHPStan level 9, Pest (524 passed) — all green. Part 3 of the dashboard polish plan.