### PR TITLE
fix(ui): resolve high-severity dashboard UX issues

### DIFF
--- a/resources/views/web/dashboard.blade.php
+++ b/resources/views/web/dashboard.blade.php
@@ -315,6 +315,30 @@
             font-weight: 700;
         }
 
+        .qm-error-banner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            background: #fdf0ef;
+            border: 1px solid #f2c6c2;
+            color: #9f2d24;
+            border-radius: 10px;
+            padding: 10px 14px;
+            margin-bottom: 16px;
+            font-size: 13px;
+        }
+
+        .qm-error-banner button {
+            background: none;
+            border: 0;
+            color: inherit;
+            font-size: 16px;
+            line-height: 1;
+            padding: 2px 4px;
+            cursor: pointer;
+        }
+
         .qm-icon-button {
             width: 40px;
             display: grid;
@@ -1184,7 +1208,7 @@
                 <div class="qm-brand-mark">Q</div>
                 <div>
                     <strong>Queue Monitor</strong>
-                    <span>Production</span>
+                    <span>{{ ucfirst(app()->environment()) }}</span>
                 </div>
             </a>
 
@@ -1229,10 +1253,6 @@
                         <input type="text" x-model="filters.search" @keydown.enter.prevent="navigateTo('jobs'); resetPaginationAndFetch()" placeholder="Search job, queue, UUID">
                     </label>
 
-                    <select class="qm-select" aria-label="Environment">
-                        <option>Production</option>
-                    </select>
-
                     <button type="button" class="qm-chip" :class="{ live: isLive }" :aria-pressed="isLive" @click="toggleLive()">
                         <svg viewBox="0 0 24 24"><path d="M5 12h4l3-8 3 16 3-8h1"></path></svg>
                         <span x-text="isLive ? 'Live' : 'Paused'">Live</span>
@@ -1251,6 +1271,11 @@
             </header>
 
             <main class="qm-content">
+
+            <div x-show="error" x-cloak class="qm-error-banner" role="alert">
+                <span x-text="error"></span>
+                <button type="button" aria-label="Dismiss error" @click="error = null">&times;</button>
+            </div>
 
             {{-- ==================== TAB CONTENT (hidden when viewing job detail or drill-down) ==================== --}}
             <div x-show="!jobView && !drillDown">
@@ -1291,13 +1316,13 @@
                             <div class="qm-panel-head">
                                 <div class="qm-panel-title">
                                     <strong>Queue latency and backlog</strong>
-                                    <span>Processing trend over the last 60 minutes</span>
+                                    <span x-text="'Processing trend over the last ' + chartRangeLabel()">Processing trend over the last hour</span>
                                 </div>
                                 <div class="qm-segmented" aria-label="Time range">
-                                    <button type="button" class="qm-segment">15m</button>
-                                    <button type="button" class="qm-segment active">1h</button>
-                                    <button type="button" class="qm-segment">6h</button>
-                                    <button type="button" class="qm-segment">24h</button>
+                                    <button type="button" class="qm-segment" :class="{ active: chartRange === 15 }" @click="setChartRange(15)">15m</button>
+                                    <button type="button" class="qm-segment" :class="{ active: chartRange === 60 }" @click="setChartRange(60)">1h</button>
+                                    <button type="button" class="qm-segment" :class="{ active: chartRange === 360 }" @click="setChartRange(360)">6h</button>
+                                    <button type="button" class="qm-segment" :class="{ active: chartRange === 1440 }" @click="setChartRange(1440)">24h</button>
                                 </div>
                             </div>
                             <div class="qm-chart-area">
@@ -1310,7 +1335,7 @@
                                         </button>
                                     </template>
                                     <template x-if="!loading.overview && overview.queues.length === 0">
-                                        <div class="qm-queue-bar"><span>default</span><div class="qm-bar-track"><i class="qm-bar-fill" style="width: 12%"></i></div></div>
+                                        <div class="qm-queue-bar"><span>No queues seen in the last hour</span></div>
                                     </template>
                                 </div>
                             </div>
@@ -1340,7 +1365,7 @@
                                     </thead>
                                     <tbody>
                                         <template x-for="job in attentionJobs().slice(0, 6)" :key="job.uuid">
-                                            <tr class="cursor-pointer" :class="{ 'selected': selectedOverviewJob()?.uuid === job.uuid }" @click="openJobView(job.uuid)">
+                                            <tr class="cursor-pointer" title="Select job" :class="{ 'selected': selectedOverviewJob()?.uuid === job.uuid }" @click="selectedOverviewUuid = job.uuid">
                                                 <td><span class="qm-status" :class="statusTone(job.status?.value)" x-text="job.status?.label || job.status?.value || 'Unknown'"></span></td>
                                                 <td><strong x-text="job.job_class"></strong><span x-text="job.uuid ? 'uuid ' + job.uuid.slice(0, 8) : ''"></span></td>
                                                 <td x-text="job.queue || '-'"></td>
@@ -1391,7 +1416,7 @@
                             <div class="qm-action-row">
                                 <button type="button" class="qm-action-button primary" @click="replayJob(selectedOverviewJob()?.uuid)">Retry</button>
                                 <button type="button" class="qm-action-button" @click="openJobView(selectedOverviewJob()?.uuid)">Inspect</button>
-                                <button type="button" class="qm-action-button" @click="confirmDeleteJob(selectedOverviewJob()?.uuid)">Ignore</button>
+                                <button type="button" class="qm-action-button" @click="confirmDeleteJob(selectedOverviewJob()?.uuid)">Delete</button>
                             </div>
                         </div>
                         <div class="qm-detail" x-show="!selectedOverviewJob()">
@@ -2996,6 +3021,10 @@
                 autoscale: {},
                 horizonAvailable: false,
 
+                // Overview state
+                chartRange: 60,
+                selectedOverviewUuid: null,
+
                 // Jobs tab state
                 filters: { search: '', statuses: [], queue: '', dateFrom: '', dateTo: '', showAdvanced: false, jobClass: '', server: '', minAttempts: '', minDuration: '' },
                 availableQueues: [],
@@ -3157,7 +3186,11 @@
                     if (this.jobView) { this.fetchJobDetail(this.jobView); return; }
                     if (this.drillDown) { this.refreshDrillDown(); return; }
                     if (this.activeTab === 'overview') { this.fetchOverview(); this.fetchHealth(); }
-                    else if (this.activeTab === 'jobs') this.fetchJobs();
+                    else if (this.activeTab === 'jobs') {
+                        // Don't move rows under the user's cursor while they are
+                        // building a selection; manual refresh still works.
+                        if (force || this.selectedJobs.length === 0) this.fetchJobs();
+                    }
                     else if (this.activeTab === 'analytics') this.fetchAnalytics();
                     else if (this.activeTab === 'health') this.fetchHealth();
                     else if (this.activeTab === 'infrastructure') this.fetchInfrastructure();
@@ -3220,7 +3253,18 @@
                 },
 
                 selectedOverviewJob() {
-                    return this.attentionJobs()[0] || null;
+                    const jobs = this.attentionJobs();
+                    return jobs.find(job => job.uuid === this.selectedOverviewUuid) || jobs[0] || null;
+                },
+
+                setChartRange(minutes) {
+                    if (this.chartRange === minutes) return;
+                    this.chartRange = minutes;
+                    this.fetchOverview();
+                },
+
+                chartRangeLabel() {
+                    return { 15: '15 minutes', 60: 'hour', 360: '6 hours', 1440: '24 hours' }[this.chartRange] || 'hour';
                 },
 
                 failureRateLabel() {
@@ -3449,7 +3493,7 @@
                 async fetchOverview() {
                     return this.runLatest('overview', async () => {
                         try {
-                        const data = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.metrics") }}');
+                        const data = await this.fetchWithRetry('{{ route("queue-monitor.dashboard.metrics") }}?minutes=' + this.chartRange);
                         this.overview.stats = data.stats || {};
                         this.overview.queues = data.queues || [];
                         this.overview.alerts = data.alerts || {};
@@ -3485,6 +3529,9 @@
                         const data = await this.fetchWithRetry(`{{ route("queue-monitor.dashboard.jobs") }}?${params.toString()}`);
                         this.jobs.data = data.data || [];
                         this.jobs.meta = data.meta || {};
+                        // Drop selections that are no longer on the current page so
+                        // batch actions only ever target visible rows.
+                        this.selectedJobs = this.selectedJobs.filter(uuid => this.jobs.data.some(job => job.uuid === uuid));
                         this.pagination.total = data.meta?.total || 0;
                         const metaQueues = data.meta?.available_queues || [];
                         if (Array.isArray(metaQueues)) this.availableQueues = metaQueues;

--- a/src/Http/Controllers/DashboardMetricsController.php
+++ b/src/Http/Controllers/DashboardMetricsController.php
@@ -33,11 +33,19 @@ class DashboardMetricsController extends Controller
         private readonly DashboardCacheService $dashboardCache,
     ) {}
 
+    /** Time ranges (in minutes) the overview throughput chart may request. */
+    private const THROUGHPUT_RANGES = [15, 60, 360, 1440];
+
     /**
      * Overview tab: stats, queues, alerts, recent jobs, charts
      */
-    public function overview(): JsonResponse
+    public function overview(Request $request): JsonResponse
     {
+        $minutes = (int) $request->query('minutes', '60');
+        if (! in_array($minutes, self::THROUGHPUT_RANGES, true)) {
+            $minutes = 60;
+        }
+
         $globalStats = $this->statsRepository->getGlobalStatistics();
         $queueHealth = $this->statsRepository->getQueueHealth();
 
@@ -62,7 +70,7 @@ class DashboardMetricsController extends Controller
             'recent_jobs' => $recentJobs,
             'charts' => [
                 'distribution' => $chartData,
-                'throughput' => $this->statsRepository->getThroughputByMinute(60),
+                'throughput' => $this->statsRepository->getThroughputByMinute($minutes),
             ],
             'horizon_available' => class_exists('Laravel\Horizon\Horizon'),
         ]);

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -156,6 +156,24 @@ test('metrics endpoint includes throughput data', function () {
     $response->assertJsonStructure(['charts' => ['throughput', 'distribution']]);
 });
 
+test('metrics endpoint honours the requested throughput range', function () {
+    JobMonitor::factory()->count(5)->create(['queued_at' => now()->subMinutes(5)]);
+
+    $response = getJson(route('queue-monitor.dashboard.metrics').'?minutes=15');
+
+    $response->assertOk();
+    expect($response->json('charts.throughput'))->toHaveCount(16);
+});
+
+test('metrics endpoint falls back to an hour for unknown throughput ranges', function () {
+    JobMonitor::factory()->count(5)->create(['queued_at' => now()->subMinutes(5)]);
+
+    $response = getJson(route('queue-monitor.dashboard.metrics').'?minutes=999');
+
+    $response->assertOk();
+    expect($response->json('charts.throughput'))->toHaveCount(61);
+});
+
 test('drill-down endpoint returns queue detail', function () {
     JobMonitor::factory()->count(5)->create(['queue' => 'payments']);
     JobMonitor::factory()->failed()->count(2)->create(['queue' => 'payments']);


### PR DESCRIPTION
Part 2 of the dashboard polish plan (stacked on #31; retargets to main when #31 merges). Fixes the eight high-severity findings from the dashboard audit:

- **Error state is finally rendered** — a dismissible banner under the topbar (previously `error` was set in five places but never shown; a dead dashboard just served stale data).
- **'Ignore' actually deleted the job** — relabelled Delete.
- **Time-range control wired** — 15m/1h/6h/24h now drive the throughput chart via a whitelisted `?minutes` param (controller + repository already supported it); previously the buttons did nothing.
- **Dead Environment select removed**; the sidebar brand shows the real `app()->environment()` instead of hardcoded 'Production'.
- **Honest empty state** — no more fabricated 'default' queue with a fake 12% bar.
- **Overview attention list is genuinely selectable** — clicking a row selects it for the side panel; previously the panel always tracked whichever job sorted first, so Retry/Delete could silently target a different job every 3 seconds.
- **Batch actions only target visible rows** — selections are reconciled after every fetch, and auto-refresh pauses on the Jobs tab while a selection is active.

Includes tests for the throughput range param (whitelist + fallback). Verified in a browser against the rendered dashboard: banner shows/dismisses, range buttons move the active state and refetch, row click selects without navigating. Gates: pint, PHPStan level 9, Pest (523 passed), assets rebuild clean.