### PR TITLE
fix(security,correctness,perf): resolve verified platform-review findings

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -162,6 +162,13 @@ return [
         'enabled' => env('QUEUE_MONITOR_CACHE_ENABLED', true),
         'store' => env('QUEUE_MONITOR_CACHE_STORE'),
         'ttl' => env('QUEUE_MONITOR_CACHE_TTL', 300), // seconds
+
+        // Minimum seconds between statistics-cache version bumps. Job lifecycle
+        // writes invalidate the cache; without this throttle a busy queue
+        // invalidates faster than any entry can be reused. The first write
+        // after a quiet period still invalidates immediately.
+        'bust_throttle_seconds' => env('QUEUE_MONITOR_CACHE_BUST_THROTTLE', 5),
+
         'prefix' => 'queue_monitor_',
     ],
 

--- a/src/Actions/Core/RecordJobQueuedAction.php
+++ b/src/Actions/Core/RecordJobQueuedAction.php
@@ -114,18 +114,22 @@ final readonly class RecordJobQueuedAction
 
         $payload = $jobInstance->payload();
         $command = $payload['data']['command'] ?? null;
+        $commandName = $payload['data']['commandName'] ?? null;
 
-        if (! is_string($command) || $command === '') {
+        if (! is_string($command) || $command === '' || ! is_string($commandName) || $commandName === '') {
             return null;
         }
 
         try {
-            $resolved = unserialize($command);
+            // Restrict deserialization to the declared command class — the
+            // serialized blob comes from the queue store, so an unrestricted
+            // unserialize() would be an object-injection entry point.
+            $resolved = unserialize($command, ['allowed_classes' => [$commandName]]);
         } catch (\Throwable) {
             return null;
         }
 
-        return is_object($resolved) ? $resolved : null;
+        return $resolved instanceof $commandName ? $resolved : null;
     }
 
     /**

--- a/src/Actions/Core/RecordJobTimeoutAction.php
+++ b/src/Actions/Core/RecordJobTimeoutAction.php
@@ -28,7 +28,9 @@ final readonly class RecordJobTimeoutAction
         }
 
         $jobId = $job->getJobId();
-        $jobMonitor = $this->repository->findByJobId($jobId);
+        // Use the latest attempt, matching completed/failed recording — a
+        // first-match lookup would mark an earlier attempt's row on a retry.
+        $jobMonitor = $this->repository->findLatestAttemptByJobId($jobId);
 
         if ($jobMonitor === null) {
             return;

--- a/src/Actions/ResolveStuckJobAction.php
+++ b/src/Actions/ResolveStuckJobAction.php
@@ -44,9 +44,18 @@ final readonly class ResolveStuckJobAction
                 $this->repository->delete($uuid);
                 $resolved++;
             } elseif ($action === 'retry') {
+                // completed_at is the schema column; finished_at does not exist
+                // and was silently dropped, leaving resolved rows with no
+                // completion timestamp or duration.
+                $completedAt = now();
+                $durationMs = $job->started_at !== null
+                    ? max(0, (int) $job->started_at->diffInMilliseconds($completedAt))
+                    : null;
+
                 $this->repository->update($uuid, [
                     'status' => JobStatus::TIMEOUT,
-                    'finished_at' => now(),
+                    'completed_at' => $completedAt,
+                    'duration_ms' => $durationMs,
                 ]);
                 $resolved++;
 

--- a/src/Commands/HealthCheckCommand.php
+++ b/src/Commands/HealthCheckCommand.php
@@ -25,31 +25,35 @@ class HealthCheckCommand extends Command
 
         if ($this->option('readiness')) {
             $readiness = $healthCheck->readiness();
+            // The exit code reflects the check outcome regardless of output
+            // format — the --json path is exactly what CI/deploy gates script.
+            $exit = $readiness['status'] === 'ready' ? self::SUCCESS : self::FAILURE;
 
             if ($this->option('json')) {
                 $json = json_encode($readiness, JSON_PRETTY_PRINT);
                 $this->line($json !== false ? $json : '{}');
 
-                return self::SUCCESS;
+                return $exit;
             }
 
             $this->displayReadinessStatus($readiness);
 
-            return $readiness['status'] === 'ready' ? self::SUCCESS : self::FAILURE;
+            return $exit;
         }
 
         $health = $healthCheck->check();
+        $exit = $health['status'] === 'healthy' ? self::SUCCESS : self::FAILURE;
 
         if ($this->option('json')) {
             $json = json_encode($health, JSON_PRETTY_PRINT);
             $this->line($json !== false ? $json : '{}');
 
-            return self::SUCCESS;
+            return $exit;
         }
 
         $this->displayHealthStatus($health);
 
-        return $health['status'] === 'healthy' ? self::SUCCESS : self::FAILURE;
+        return $exit;
     }
 
     /**

--- a/src/Http/Controllers/BatchOperationsController.php
+++ b/src/Http/Controllers/BatchOperationsController.php
@@ -7,6 +7,7 @@ namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 use Cbox\LaravelQueueMonitor\Actions\Batch\BatchDeleteAction;
 use Cbox\LaravelQueueMonitor\Actions\Batch\BatchReplayAction;
 use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -25,12 +26,7 @@ class BatchOperationsController extends Controller
     {
         $maxJobsLimit = $this->maxJobsLimit();
 
-        $validated = $request->validate([
-            'uuids' => 'sometimes|array',
-            'uuids.*' => 'string|uuid',
-            'filters' => 'sometimes|array',
-            'max_jobs' => 'sometimes|integer|min:1|max:'.$maxJobsLimit,
-        ]);
+        $validated = $request->validate($this->batchRules($maxJobsLimit));
 
         if (isset($validated['uuids'])) {
             $result = $this->batchReplayAction->executeByUuids($validated['uuids']);
@@ -56,12 +52,7 @@ class BatchOperationsController extends Controller
     {
         $maxJobsLimit = $this->maxJobsLimit();
 
-        $validated = $request->validate([
-            'uuids' => 'sometimes|array',
-            'uuids.*' => 'string|uuid',
-            'filters' => 'sometimes|array',
-            'max_jobs' => 'sometimes|integer|min:1|max:'.$maxJobsLimit,
-        ]);
+        $validated = $request->validate($this->batchRules($maxJobsLimit));
 
         if (isset($validated['uuids'])) {
             $result = $this->batchDeleteAction->executeByUuids($validated['uuids']);
@@ -84,5 +75,35 @@ class BatchOperationsController extends Controller
         $value = config('queue-monitor.batch.max_jobs', 1000);
 
         return is_numeric($value) ? max(1, (int) $value) : 1000;
+    }
+
+    /**
+     * Batch actions are destructive, so an unrecognised filter value must be
+     * rejected, never silently dropped — a dropped status filter widens the
+     * match to every job instead of narrowing it.
+     *
+     * @return array<string, string>
+     */
+    private function batchRules(int $maxJobsLimit): array
+    {
+        return [
+            'uuids' => 'sometimes|array|max:'.$maxJobsLimit,
+            'uuids.*' => 'string|uuid',
+            'filters' => 'sometimes|array',
+            'filters.statuses' => 'sometimes|array',
+            'filters.statuses.*' => 'string|in:'.implode(',', JobStatus::values()),
+            'filters.queues' => 'sometimes|array',
+            'filters.queues.*' => 'string',
+            'filters.job_classes' => 'sometimes|array',
+            'filters.job_classes.*' => 'string',
+            'filters.server_names' => 'sometimes|array',
+            'filters.server_names.*' => 'string',
+            'filters.search' => 'sometimes|string',
+            'filters.queued_after' => 'sometimes',
+            'filters.queued_before' => 'sometimes',
+            'filters.min_attempts' => 'sometimes|integer|min:1',
+            'filters.min_duration_ms' => 'sometimes|integer|min:0',
+            'max_jobs' => 'sometimes|integer|min:1|max:'.$maxJobsLimit,
+        ];
     }
 }

--- a/src/Http/Controllers/DashboardDrillDownController.php
+++ b/src/Http/Controllers/DashboardDrillDownController.php
@@ -8,6 +8,7 @@ use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentStatisticsRepository;
 use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Utilities\PayloadRedactor;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -236,11 +237,27 @@ class DashboardDrillDownController extends Controller
             'maxExceptions', 'failOnTimeout', 'tries', 'timeout', 'uniqueFor',
             'uniqueId', 'uniqueVia'];
 
+        /** @var array<string> $sensitiveKeys */
+        $sensitiveKeys = config('queue-monitor.api.sensitive_keys', []);
+
         // Match property name followed by its value
         if (preg_match_all('/s:\d+:"([^"]+)";(s:\d+:"([^"]*)"|i:(\d+)|d:([\d.]+)|b:([01])|N;)/', $command, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $name = $match[1];
                 if (in_array($name, $skip, true)) {
+                    continue;
+                }
+
+                // This summary is built from the raw serialized command, which
+                // the payload redactor never sees — so apply the operator's
+                // sensitive-key policy here too, or a property named e.g.
+                // "password" would leak its value on the drill-down.
+                if (PayloadRedactor::isSensitive($name, $sensitiveKeys)) {
+                    $props[] = "{$name}: [REDACTED]";
+                    if (count($props) >= 3) {
+                        break;
+                    }
+
                     continue;
                 }
 

--- a/src/Http/Controllers/PruneController.php
+++ b/src/Http/Controllers/PruneController.php
@@ -25,7 +25,7 @@ class PruneController extends Controller
             'days' => 'sometimes|integer|min:1',
             'max_rows' => 'sometimes|integer|min:1',
             'statuses' => 'sometimes|array',
-            'statuses.*' => 'string',
+            'statuses.*' => 'string|in:'.implode(',', JobStatus::values()),
         ]);
 
         $daysValue = $validated['days'] ?? null;

--- a/src/Http/Controllers/StuckJobController.php
+++ b/src/Http/Controllers/StuckJobController.php
@@ -47,8 +47,17 @@ class StuckJobController extends Controller
             'action' => 'required|in:delete,retry',
         ]);
 
+        $stuckMinutes = config('queue-monitor.health.stuck_job_minutes', 30);
+        $stuckMinutes = is_numeric($stuckMinutes) ? (int) $stuckMinutes : 30;
+
+        $batchLimit = config('queue-monitor.batch.max_jobs', 1000);
+        $batchLimit = is_numeric($batchLimit) ? max(1, (int) $batchLimit) : 1000;
+
         /** @var list<string> $stuckJobs */
-        $stuckJobs = QueryBuilderHelper::stuck(30)->pluck('uuid')->toArray();
+        $stuckJobs = QueryBuilderHelper::stuck($stuckMinutes)
+            ->limit($batchLimit)
+            ->pluck('uuid')
+            ->toArray();
 
         if (empty($stuckJobs)) {
             return response()->json(['message' => 'No stuck jobs found', 'resolved' => 0, 'replayed' => 0, 'errors' => []]);

--- a/src/Http/Transformers/JobMonitorTransformer.php
+++ b/src/Http/Transformers/JobMonitorTransformer.php
@@ -102,7 +102,7 @@ final class JobMonitorTransformer
                 'started_at' => $job->started_at?->toIso8601String(),
                 'completed_at' => $job->completed_at?->toIso8601String(),
             ],
-            'tags' => $job->tags,
+            'tags' => is_array($job->tags) ? PayloadRedactor::redact($job->tags, $sensitiveKeys) : $job->tags,
             'is_failed' => $job->isFailed(),
             'is_retryable' => $job->isRetryable(),
         ];

--- a/src/Services/DashboardCacheService.php
+++ b/src/Services/DashboardCacheService.php
@@ -21,10 +21,33 @@ final class DashboardCacheService
         }
 
         $cache = $this->cacheStore();
-        $versionKey = $this->versionKey();
 
+        // Throttle the version bump: a busy queue fires this on every job
+        // lifecycle write, and without a throttle the version increments
+        // faster than any cache entry can be reused — so the statistics cache
+        // is perpetually cold exactly when the table is largest. The leading
+        // edge still invalidates immediately, so new data shows up promptly;
+        // subsequent writes within the window are absorbed into that one bump.
+        $throttleSeconds = $this->bustThrottleSeconds();
+        if ($throttleSeconds > 0 && ! $cache->add($this->throttleKey(), 1, now()->addSeconds($throttleSeconds))) {
+            return;
+        }
+
+        $versionKey = $this->versionKey();
         $cache->add($versionKey, 1, now()->addYear());
         $cache->increment($versionKey);
+    }
+
+    private function bustThrottleSeconds(): int
+    {
+        $value = config('queue-monitor.cache.bust_throttle_seconds', 5);
+
+        return is_numeric($value) ? max(0, (int) $value) : 5;
+    }
+
+    private function throttleKey(): string
+    {
+        return $this->cachePrefix().'bust_throttle';
     }
 
     public function remember(string $key, \Closure $callback, ?int $ttl = null): mixed

--- a/src/Services/InfrastructureService.php
+++ b/src/Services/InfrastructureService.php
@@ -206,8 +206,36 @@ final class InfrastructureService
             $driver
         );
 
+        // Resolve each queue's SLA target inside SQL so compliance is computed
+        // with a single grouped aggregate — hydrating every last-hour job row
+        // into PHP to filter it here would OOM on a busy install, and this runs
+        // every few seconds on the infrastructure and autoscale tabs.
+        $specificTargets = array_filter(
+            $slaTargets,
+            fn (string $queue): bool => $queue !== '*',
+            ARRAY_FILTER_USE_KEY
+        );
+
+        if ($specificTargets === []) {
+            $targetExpr = '?';
+            $bindings = [$defaultTarget];
+        } else {
+            $targetExpr = 'CASE queue';
+            $bindings = [];
+            foreach ($specificTargets as $queue => $target) {
+                $targetExpr .= ' WHEN ? THEN ?';
+                $bindings[] = $queue;
+                $bindings[] = (int) $target;
+            }
+            $targetExpr .= ' ELSE ? END';
+            $bindings[] = $defaultTarget;
+        }
+
         $rows = $this->jobTable()
-            ->selectRaw('queue, COUNT(*) as total')
+            ->selectRaw(
+                "queue, COUNT(*) as total, SUM(CASE WHEN {$pickupExpr} <= {$targetExpr} THEN 1 ELSE 0 END) as within_sla",
+                $bindings
+            )
             ->whereNotNull('started_at')
             ->where('created_at', '>=', now()->subHour())
             ->groupBy('queue')
@@ -217,21 +245,12 @@ final class InfrastructureService
             return ['available' => true, 'per_queue' => [], 'source' => empty($slaTargets) ? 'default' : 'autoscale'];
         }
 
-        // For per-queue SLA with different targets, we need pickup times per queue.
-        // Use a single query to get all pickup seconds, grouped by queue.
-        $allPickups = $this->jobTable()
-            ->selectRaw("queue, {$pickupExpr} as pickup_seconds")
-            ->whereNotNull('started_at')
-            ->where('created_at', '>=', now()->subHour())
-            ->get()
-            ->groupBy('queue');
-
         $perQueue = [];
-        foreach ($allPickups as $queueName => $queueRows) {
-            $queueStr = (string) $queueName;
+        foreach ($rows as $row) {
+            $queueStr = (string) $row->queue;
             $target = $slaTargets[$queueStr] ?? $defaultTarget;
-            $total = $queueRows->count();
-            $within = $queueRows->filter(fn ($row) => (float) $row->pickup_seconds <= $target)->count();
+            $total = (int) $row->total;
+            $within = (int) $row->within_sla;
 
             $perQueue[] = [
                 'queue' => $queueStr,

--- a/src/Utilities/PayloadRedactor.php
+++ b/src/Utilities/PayloadRedactor.php
@@ -57,7 +57,7 @@ class PayloadRedactor
      *
      * @param  array<string>  $sensitiveKeys
      */
-    private static function isSensitive(string $key, array $sensitiveKeys): bool
+    public static function isSensitive(string $key, array $sensitiveKeys): bool
     {
         $normalizedKey = strtolower($key);
 

--- a/tests/Feature/Actions/TimeoutAndMetricsTest.php
+++ b/tests/Feature/Actions/TimeoutAndMetricsTest.php
@@ -31,6 +31,32 @@ test('timeout action marks job as timed out', function () {
     expect($monitor->exception_message)->toBe('Job exceeded maximum execution time');
 });
 
+test('timeout action marks the latest attempt, not the first', function () {
+    $first = JobMonitor::factory()->failed()->create([
+        'job_id' => 'retry-job',
+        'attempt' => 1,
+        'started_at' => now()->subMinutes(5),
+    ]);
+    $latest = JobMonitor::factory()->processing()->create([
+        'job_id' => 'retry-job',
+        'attempt' => 2,
+        'started_at' => now()->subSeconds(30),
+    ]);
+
+    $mockJob = Mockery::mock(Job::class);
+    $mockJob->shouldReceive('getJobId')->andReturn('retry-job');
+
+    $event = new stdClass;
+    $event->job = $mockJob;
+
+    app(RecordJobTimeoutAction::class)->execute($event);
+
+    $first->refresh();
+    $latest->refresh();
+    expect($latest->status)->toBe(JobStatus::TIMEOUT);
+    expect($first->status)->toBe(JobStatus::FAILED);
+});
+
 test('timeout action returns early when no job in event', function () {
     $event = new stdClass;
 

--- a/tests/Feature/Commands/HealthCheckCommandTest.php
+++ b/tests/Feature/Commands/HealthCheckCommandTest.php
@@ -74,3 +74,18 @@ test('health check command readiness supports json output', function () {
     expect($output)->toContain('"status"');
     expect($output)->toContain('"access_control"');
 });
+
+test('health check readiness --json exits non-zero when not ready', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    LaravelQueueMonitor::$authUsing = null;
+    config()->set('queue-monitor.api.enabled', true);
+    config()->set('queue-monitor.api.middleware', ['api']);
+    config()->set('queue-monitor.storage.store_payload', true);
+
+    // The JSON path is exactly what a CI/deploy gate scripts, so it must carry
+    // the failing exit code, not a blanket success.
+    $exitCode = Artisan::call('queue-monitor:health', ['--readiness' => true, '--json' => true]);
+
+    expect($exitCode)->toBe(1);
+    expect(Artisan::output())->toContain('"status"');
+});

--- a/tests/Feature/Security/R1RegressionTest.php
+++ b/tests/Feature/Security/R1RegressionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\Actions\ResolveStuckJobAction;
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+
+use function Pest\Laravel\postJson;
+
+test('resolving a stuck job records a completion timestamp and duration', function () {
+    $job = JobMonitor::factory()->processing()->create([
+        'started_at' => now()->subMinutes(45),
+        'completed_at' => null,
+        'duration_ms' => null,
+    ]);
+
+    $result = app(ResolveStuckJobAction::class)->execute([$job->uuid], 'delete');
+
+    // (delete path) — the retry path is what writes the timestamp; assert on it:
+    expect($result['resolved'])->toBe(1);
+
+    $retryJob = JobMonitor::factory()->processing()->create([
+        'started_at' => now()->subMinutes(30),
+        'completed_at' => null,
+        'duration_ms' => null,
+    ]);
+
+    app(ResolveStuckJobAction::class)->execute([$retryJob->uuid], 'retry');
+
+    $retryJob->refresh();
+    expect($retryJob->status)->toBe(JobStatus::TIMEOUT);
+    expect($retryJob->completed_at)->not->toBeNull();
+    expect($retryJob->duration_ms)->toBeGreaterThan(0);
+});
+
+test('batch delete rejects an invalid status filter instead of widening the match', function () {
+    JobMonitor::factory()->count(3)->create(['status' => 'completed']);
+    JobMonitor::factory()->count(2)->failed()->create();
+
+    // A misspelled status must fail validation, not silently drop the filter
+    // and delete across every job.
+    $response = postJson('/api/queue-monitor/batch/delete', [
+        'filters' => ['statuses' => ['faield']],
+        'max_jobs' => 1000,
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors('filters.statuses.0');
+    expect(JobMonitor::count())->toBe(5);
+});
+
+test('batch delete still works with a valid status filter', function () {
+    JobMonitor::factory()->count(3)->create(['status' => 'completed']);
+    JobMonitor::factory()->count(2)->failed()->create();
+
+    $response = postJson('/api/queue-monitor/batch/delete', [
+        'filters' => ['statuses' => ['failed']],
+        'max_jobs' => 1000,
+    ]);
+
+    $response->assertOk();
+    expect(JobMonitor::where('status', 'completed')->count())->toBe(3);
+    expect(JobMonitor::where('status', 'failed')->count())->toBe(0);
+});
+
+test('drill-down job summary redacts sensitive constructor properties', function () {
+    config()->set('queue-monitor.api.sensitive_keys', ['password', 'token']);
+
+    // A command serialized with a sensitive property; the drill-down builds its
+    // summary from this raw blob, so it must apply the redaction policy itself.
+    $command = 'O:8:"stdClass":2:{s:8:"password";s:14:"hunter2-secret";s:7:"user_id";i:42;}';
+
+    JobMonitor::factory()->create([
+        'queue' => 'payments',
+        'payload' => ['data' => ['command' => $command]],
+    ]);
+
+    $response = $this->getJson(route('queue-monitor.dashboard.drill-down', ['type' => 'queue', 'value' => 'payments']));
+
+    $response->assertOk();
+    $summary = collect($response->json('recent_jobs'))->pluck('summary')->implode(' ');
+    expect($summary)->not->toContain('hunter2-secret');
+    expect($summary)->toContain('[REDACTED]');
+});
+
+test('prune rejects an unknown status with 422 instead of a 500', function () {
+    $response = postJson('/api/queue-monitor/prune', [
+        'statuses' => ['bogus'],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors('statuses.0');
+});

--- a/tests/Feature/Security/RouteAuthorizationTest.php
+++ b/tests/Feature/Security/RouteAuthorizationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
+
+use function Pest\Laravel\getJson;
+
+/**
+ * The middleware unit tests prove the gate's logic; these prove it is actually
+ * wired onto the routes, so removing it from the route groups fails a test
+ * instead of silently shipping a public dashboard.
+ */
+beforeEach(function () {
+    // Drop the permissive test callback so the default (deny outside local)
+    // applies, and make the app report a non-local environment.
+    LaravelQueueMonitor::$authUsing = null;
+    config()->set('app.env', 'production');
+    app()->detectEnvironment(fn () => 'production');
+});
+
+test('the dashboard route denies when no auth callback is registered', function () {
+    getJson(route('queue-monitor.dashboard'))->assertForbidden();
+});
+
+test('the jobs API route denies when no auth callback is registered', function () {
+    config()->set('queue-monitor.api.enabled', true);
+
+    getJson(route('queue-monitor.jobs.index'))->assertForbidden();
+});
+
+test('a registered auth callback that denies is honoured on the routes', function () {
+    LaravelQueueMonitor::auth(fn () => false);
+
+    getJson(route('queue-monitor.dashboard'))->assertForbidden();
+});

--- a/tests/Feature/Services/SlaAndCacheTest.php
+++ b/tests/Feature/Services/SlaAndCacheTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\InfrastructureService;
+
+test('SLA compliance is computed per queue with distinct targets in SQL', function () {
+    config()->set('queue-autoscale.queues', [
+        'fast' => ['max_pickup_time_seconds' => 5],
+        'slow' => ['max_pickup_time_seconds' => 60],
+    ]);
+
+    // fast queue: one within 5s, one over → 50%
+    JobMonitor::factory()->create(['queue' => 'fast', 'queued_at' => now()->subSeconds(10), 'started_at' => now()->subSeconds(8)]); // 2s pickup, within
+    JobMonitor::factory()->create(['queue' => 'fast', 'queued_at' => now()->subSeconds(30), 'started_at' => now()->subSeconds(10)]); // 20s pickup, breached
+    // slow queue: both within 60s → 100%
+    JobMonitor::factory()->create(['queue' => 'slow', 'queued_at' => now()->subSeconds(40), 'started_at' => now()->subSeconds(10)]); // 30s pickup, within
+
+    $sla = app(InfrastructureService::class)->getSlaData();
+    $byQueue = collect($sla['per_queue'])->keyBy('queue');
+
+    expect($byQueue['fast']['total'])->toBe(2);
+    expect($byQueue['fast']['within'])->toBe(1);
+    expect($byQueue['fast']['compliance'])->toBe(50.0);
+    expect($byQueue['slow']['within'])->toBe(1);
+    expect($byQueue['slow']['compliance'])->toBe(100.0);
+});
+
+test('SLA data works with only a default target and no per-queue config', function () {
+    config()->set('queue-autoscale.queues', []);
+
+    JobMonitor::factory()->create(['queue' => 'default', 'queued_at' => now()->subSeconds(10), 'started_at' => now()->subSeconds(8)]);
+
+    $sla = app(InfrastructureService::class)->getSlaData();
+
+    expect($sla['available'])->toBeTrue();
+    expect($sla['per_queue'])->toHaveCount(1);
+    expect($sla['per_queue'][0]['queue'])->toBe('default');
+});
+
+test('cache bust throttles repeated version bumps within the window', function () {
+    config()->set('queue-monitor.cache.enabled', true);
+    config()->set('queue-monitor.cache.bust_throttle_seconds', 60);
+
+    $service = app(DashboardCacheService::class);
+
+    $service->remember('probe', fn () => 'warm');
+    $keyBefore = $service->scopedKey('probe');
+
+    // A burst of busts within the window collapses to one version bump.
+    $service->bust();
+    $service->bust();
+    $service->bust();
+
+    $keyAfter = $service->scopedKey('probe');
+
+    // Exactly one increment, so the warm entry survives repeated writes.
+    expect($keyAfter)->not->toBe($keyBefore);
+    $keyAfterAgain = (function () use ($service) {
+        $service->bust();
+
+        return $service->scopedKey('probe');
+    })();
+    expect($keyAfterAgain)->toBe($keyAfter);
+});


### PR DESCRIPTION
First fix batch (R1) from the pre-1.9.0 platform review. Every finding here was adversarially verified — the three security/correctness leaks with executed proof tests, now inverted into regression tests.

## Security & correctness
- **Batch filters fail closed** — an invalid status in a batch delete/replay filter now 422s instead of being silently dropped (which widened a scoped delete to *every* job; the proof test confirmed a typo'd status wiped the table). Applies to prune too.
- **Drill-down redaction** — the drill-down summary is built from the raw serialized command, which `PayloadRedactor` never sees; it now applies `api.sensitive_keys` (a `password` property was leaking its value verbatim, defeating even the default full-command masking).
- **Tags redaction** in dashboard job detail (was raw, unlike the API resource).
- **Restricted `unserialize()`** in the job-queued capture path — pinned to the declared command class.
- **Timeout → latest attempt** — matched to completed/failed recording; a first-match lookup marked an earlier attempt's row on a retry.
- **Stuck-job resolve** writes `completed_at` + `duration_ms` (was a nonexistent `finished_at`, silently dropped); `resolve-all` uses the configured threshold + caps the batch.
- **`health --json` exit code** — the `--readiness`/health JSON paths now carry the failing exit code, the exact thing a CI/deploy gate scripts.

## Performance (the two verified P0s)
- **Cache-bust throttle** — a busy queue bumped the statistics-cache version on every job lifecycle write, so caching was perpetually cold under load. The leading edge still invalidates immediately; the rest of the window is absorbed into one bump (configurable via `cache.bust_throttle_seconds`).
- **SLA in SQL** — per-queue compliance is now a single grouped aggregate with a per-queue target CASE, instead of hydrating every last-hour job row into PHP to filter it (this runs every few seconds on two tabs).

## Tests
Route-level authorization tests (proving the gate is actually wired onto the dashboard and API routes — previously only the middleware unit was tested, so removing it from a route group passed CI), plus a regression test per finding. Gate: pint, PHPStan level 9, Pest (543 passed), composer audit — all green.