### PR TITLE
refactor(arch): extract service contracts and enforce final-by-default (campaign batch B)

### DIFF
--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -22,6 +22,18 @@ use Cbox\LaravelQueueMonitor\Repositories\Contracts\TagRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentJobMonitorRepository;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentStatisticsRepository;
 use Cbox\LaravelQueueMonitor\Repositories\Eloquent\EloquentTagRepository;
+use Cbox\LaravelQueueMonitor\Services\AlertingService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\ExportServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\InfrastructureServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\WorkerContextServiceContract;
+use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\ExportService;
+use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
+use Cbox\LaravelQueueMonitor\Services\InfrastructureService;
+use Cbox\LaravelQueueMonitor\Services\WorkerContextService;
 
 return [
     /*
@@ -304,6 +316,25 @@ return [
         JobMonitorRepositoryContract::class => EloquentJobMonitorRepository::class,
         TagRepositoryContract::class => EloquentTagRepository::class,
         StatisticsRepositoryContract::class => EloquentStatisticsRepository::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Service Bindings
+    |--------------------------------------------------------------------------
+    |
+    | Map service contracts to their concrete implementations.
+    | Every domain service is resolved through its contract, so a host can
+    | override or fake any of them by rebinding the contract here.
+    |
+    */
+    'services' => [
+        AlertingServiceContract::class => AlertingService::class,
+        DashboardCacheServiceContract::class => DashboardCacheService::class,
+        ExportServiceContract::class => ExportService::class,
+        HealthCheckServiceContract::class => HealthCheckService::class,
+        InfrastructureServiceContract::class => InfrastructureService::class,
+        WorkerContextServiceContract::class => WorkerContextService::class,
     ],
 
     /*

--- a/src/Actions/Core/RecordJobQueuedAction.php
+++ b/src/Actions/Core/RecordJobQueuedAction.php
@@ -9,7 +9,7 @@ use Cbox\LaravelQueueMonitor\DataTransferObjects\JobMonitorData;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\WorkerContextService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\WorkerContextServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\JobPayloadSerializer;
 use Illuminate\Contracts\Queue\Job as QueueJob;
 use Illuminate\Support\Facades\DB;
@@ -19,7 +19,7 @@ final readonly class RecordJobQueuedAction
 {
     public function __construct(
         private JobMonitorRepositoryContract $repository,
-        private WorkerContextService $workerContext,
+        private WorkerContextServiceContract $workerContext,
     ) {}
 
     /**

--- a/src/Actions/Core/RecordJobStartedAction.php
+++ b/src/Actions/Core/RecordJobStartedAction.php
@@ -8,7 +8,7 @@ use Cbox\LaravelQueueMonitor\DataTransferObjects\JobMonitorData;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\WorkerContextService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\WorkerContextServiceContract;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -17,7 +17,7 @@ final readonly class RecordJobStartedAction
 {
     public function __construct(
         private JobMonitorRepositoryContract $repository,
-        private WorkerContextService $workerContext,
+        private WorkerContextServiceContract $workerContext,
         private RecordJobQueuedAction $recordQueuedAction,
     ) {}
 

--- a/src/Commands/HealthCheckCommand.php
+++ b/src/Commands/HealthCheckCommand.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Commands;
 
-use Cbox\LaravelQueueMonitor\Services\AlertingService;
-use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
 use Illuminate\Console\Command;
 
 class HealthCheckCommand extends Command
@@ -17,7 +17,7 @@ class HealthCheckCommand extends Command
 
     public $description = 'Check queue monitor system health';
 
-    public function handle(HealthCheckService $healthCheck, AlertingService $alerting): int
+    public function handle(HealthCheckServiceContract $healthCheck, AlertingServiceContract $alerting): int
     {
         if ($this->option('alerts')) {
             return $this->showAlerts($alerting);
@@ -116,7 +116,7 @@ class HealthCheckCommand extends Command
     /**
      * Show active alerts
      */
-    private function showAlerts(AlertingService $alerting): int
+    private function showAlerts(AlertingServiceContract $alerting): int
     {
         $alerts = $alerting->checkAlertConditions();
 

--- a/src/Commands/QueueMonitorDashboardCommand.php
+++ b/src/Commands/QueueMonitorDashboardCommand.php
@@ -10,9 +10,9 @@ use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\TagRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\AlertingService;
-use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
-use Cbox\LaravelQueueMonitor\Services\InfrastructureService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\InfrastructureServiceContract;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 
@@ -513,7 +513,7 @@ class QueueMonitorDashboardCommand extends Command
             }
 
             try {
-                $alertingService = app(AlertingService::class);
+                $alertingService = app(AlertingServiceContract::class);
                 $this->alertsData = $alertingService->checkAlertConditions();
             } catch (\Throwable) {
                 $this->alertsData = [];
@@ -533,7 +533,7 @@ class QueueMonitorDashboardCommand extends Command
 
         if ($this->currentView === 4 && ($this->healthData === null || $now - $this->healthLastFetched > 10)) {
             try {
-                $healthService = app(HealthCheckService::class);
+                $healthService = app(HealthCheckServiceContract::class);
                 $this->healthData = $healthService->check();
                 $this->healthData['score'] = $healthService->getHealthScore();
                 $this->healthLastFetched = $now;
@@ -560,7 +560,7 @@ class QueueMonitorDashboardCommand extends Command
 
         if ($this->currentView === 6 && ($this->infrastructureData === null || $now - $this->infraLastFetched > 10)) {
             try {
-                $infraService = app(InfrastructureService::class);
+                $infraService = app(InfrastructureServiceContract::class);
                 $this->infrastructureData = [
                     'workers' => $infraService->getWorkerData(),
                     'worker_types' => $infraService->getWorkerTypeBreakdown(),

--- a/src/Http/Controllers/DashboardDrillDownController.php
+++ b/src/Http/Controllers/DashboardDrillDownController.php
@@ -6,7 +6,7 @@ namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\PayloadRedactor;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Http\JsonResponse;
@@ -24,7 +24,7 @@ class DashboardDrillDownController extends Controller
 {
     public function __construct(
         private readonly StatisticsRepositoryContract $statsRepository,
-        private readonly DashboardCacheService $dashboardCache,
+        private readonly DashboardCacheServiceContract $dashboardCache,
     ) {}
 
     /**

--- a/src/Http/Controllers/DashboardHealthController.php
+++ b/src/Http/Controllers/DashboardHealthController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\AlertingService;
-use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
-use Cbox\LaravelQueueMonitor\Services\InfrastructureService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\InfrastructureServiceContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -21,10 +21,10 @@ use Illuminate\Routing\Controller;
 class DashboardHealthController extends Controller
 {
     public function __construct(
-        private readonly InfrastructureService $infrastructureService,
+        private readonly InfrastructureServiceContract $infrastructureService,
         private readonly StatisticsRepositoryContract $statsRepository,
-        private readonly HealthCheckService $healthService,
-        private readonly AlertingService $alertingService,
+        private readonly HealthCheckServiceContract $healthService,
+        private readonly AlertingServiceContract $alertingService,
     ) {}
 
     /**

--- a/src/Http/Controllers/DashboardMetricsController.php
+++ b/src/Http/Controllers/DashboardMetricsController.php
@@ -10,8 +10,8 @@ use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\TagRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\AlertingService;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\PayloadRedactor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -30,8 +30,8 @@ class DashboardMetricsController extends Controller
         private readonly JobMonitorRepositoryContract $jobRepository,
         private readonly StatisticsRepositoryContract $statsRepository,
         private readonly TagRepositoryContract $tagRepository,
-        private readonly DashboardCacheService $dashboardCache,
-        private readonly AlertingService $alertingService,
+        private readonly DashboardCacheServiceContract $dashboardCache,
+        private readonly AlertingServiceContract $alertingService,
     ) {}
 
     /** Time ranges (in minutes) the overview throughput chart may request. */

--- a/src/Http/Controllers/ExportController.php
+++ b/src/Http/Controllers/ExportController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 
 use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
-use Cbox\LaravelQueueMonitor\Services\ExportService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\ExportServiceContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -14,7 +14,7 @@ use Illuminate\Routing\Controller;
 class ExportController extends Controller
 {
     public function __construct(
-        private readonly ExportService $exportService,
+        private readonly ExportServiceContract $exportService,
     ) {}
 
     /**

--- a/src/Http/Controllers/HealthCheckController.php
+++ b/src/Http/Controllers/HealthCheckController.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 
-use Cbox\LaravelQueueMonitor\Services\AlertingService;
-use Cbox\LaravelQueueMonitor\Services\HealthCheckService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 
 class HealthCheckController extends Controller
 {
     public function __construct(
-        private readonly HealthCheckService $healthCheck,
-        private readonly AlertingService $alerting,
+        private readonly HealthCheckServiceContract $healthCheck,
+        private readonly AlertingServiceContract $alerting,
     ) {}
 
     /**

--- a/src/LaravelQueueMonitorServiceProvider.php
+++ b/src/LaravelQueueMonitorServiceProvider.php
@@ -62,9 +62,11 @@ class LaravelQueueMonitorServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
-        // Order matters: repositories and actions must be bound before event listeners
-        // because listeners depend on action classes which depend on repositories
+        // Order matters: repositories, services, and actions must be bound before
+        // event listeners because listeners depend on action classes which depend
+        // on repositories and services
         $this->registerRepositories();
+        $this->registerServices();
         $this->registerActions();
         $this->registerEventListeners();
         $this->registerRoutes();
@@ -176,6 +178,19 @@ class LaravelQueueMonitorServiceProvider extends PackageServiceProvider
 
         foreach ($repositories as $contract => $implementation) {
             $this->app->bind($contract, $implementation);
+        }
+    }
+
+    /**
+     * Register service bindings
+     */
+    protected function registerServices(): void
+    {
+        /** @var array<string, string> $services */
+        $services = config('queue-monitor.services', []);
+
+        foreach ($services as $contract => $implementation) {
+            $this->app->singleton($contract, $implementation);
         }
     }
 

--- a/src/Listeners/JobExceptionOccurredListener.php
+++ b/src/Listeners/JobExceptionOccurredListener.php
@@ -6,7 +6,7 @@ namespace Cbox\LaravelQueueMonitor\Listeners;
 
 use Cbox\LaravelQueueMonitor\DataTransferObjects\ExceptionData;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 
 /**
@@ -19,7 +19,7 @@ use Illuminate\Queue\Events\JobExceptionOccurred;
 final class JobExceptionOccurredListener
 {
     public function __construct(
-        private readonly DashboardCacheService $dashboardCache,
+        private readonly DashboardCacheServiceContract $dashboardCache,
     ) {}
 
     public function handle(JobExceptionOccurred $event): void

--- a/src/Listeners/QueueMetricsSubscriber.php
+++ b/src/Listeners/QueueMetricsSubscriber.php
@@ -7,7 +7,7 @@ namespace Cbox\LaravelQueueMonitor\Listeners;
 use Cbox\LaravelQueueMetrics\Events\JobMetricsCompleted;
 use Cbox\LaravelQueueMetrics\Events\JobMetricsFailed;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Illuminate\Events\Dispatcher;
 
 /**
@@ -19,7 +19,7 @@ use Illuminate\Events\Dispatcher;
 final class QueueMetricsSubscriber
 {
     public function __construct(
-        private readonly DashboardCacheService $dashboardCache,
+        private readonly DashboardCacheServiceContract $dashboardCache,
     ) {}
 
     public function handleJobMetricsCompleted(JobMetricsCompleted $event): void

--- a/src/Listeners/ScalingEventListener.php
+++ b/src/Listeners/ScalingEventListener.php
@@ -8,7 +8,7 @@ use Cbox\LaravelQueueMonitor\Models\ClusterEvent;
 use Cbox\LaravelQueueMonitor\Models\ScalingEvent;
 use Illuminate\Support\Facades\Cache;
 
-class ScalingEventListener
+final class ScalingEventListener
 {
     public function handleScalingDecision(object $event): void
     {

--- a/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
+++ b/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
@@ -10,7 +10,7 @@ use Cbox\LaravelQueueMonitor\DataTransferObjects\JobMonitorData;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
 final class EloquentJobMonitorRepository implements JobMonitorRepositoryContract
 {
     public function __construct(
-        private readonly DashboardCacheService $dashboardCache,
+        private readonly DashboardCacheServiceContract $dashboardCache,
     ) {}
 
     public function create(JobMonitorData $data): JobMonitor

--- a/src/Repositories/Eloquent/EloquentStatisticsRepository.php
+++ b/src/Repositories/Eloquent/EloquentStatisticsRepository.php
@@ -8,7 +8,7 @@ use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
-use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\DatabaseExpressionHelper;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Database\Query\Builder;
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
 final readonly class EloquentStatisticsRepository implements StatisticsRepositoryContract
 {
     public function __construct(
-        private DashboardCacheService $dashboardCache,
+        private DashboardCacheServiceContract $dashboardCache,
     ) {}
 
     public function getGlobalStatistics(): array

--- a/src/Services/AlertingService.php
+++ b/src/Services/AlertingService.php
@@ -6,9 +6,10 @@ namespace Cbox\LaravelQueueMonitor\Services;
 
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
 
-final class AlertingService
+final class AlertingService implements AlertingServiceContract
 {
     /**
      * Check for alert conditions

--- a/src/Services/Contracts/AlertingServiceContract.php
+++ b/src/Services/Contracts/AlertingServiceContract.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+interface AlertingServiceContract
+{
+    /**
+     * Check for alert conditions
+     *
+     * @return array<string, array{severity: string, message: string, count: int}>
+     */
+    public function checkAlertConditions(): array;
+
+    /**
+     * Get critical alerts only
+     *
+     * @return array<string, array{severity: string, message: string, count: int}>
+     */
+    public function getCriticalAlerts(): array;
+
+    /**
+     * Check if system requires immediate attention
+     */
+    public function requiresAttention(): bool;
+}

--- a/src/Services/Contracts/DashboardCacheServiceContract.php
+++ b/src/Services/Contracts/DashboardCacheServiceContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+interface DashboardCacheServiceContract
+{
+    public function scopedKey(string $key): string;
+
+    public function bust(): void;
+
+    public function remember(string $key, \Closure $callback, ?int $ttl = null): mixed;
+}

--- a/src/Services/Contracts/ExportServiceContract.php
+++ b/src/Services/Contracts/ExportServiceContract.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
+
+interface ExportServiceContract
+{
+    /**
+     * Export jobs to CSV format
+     */
+    public function toCsv(JobFilterData $filters): string;
+
+    /**
+     * Export jobs to JSON format
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function toJson(JobFilterData $filters): array;
+
+    /**
+     * Export statistics report
+     *
+     * @return array<string, mixed>
+     */
+    public function statisticsReport(): array;
+
+    /**
+     * Export failed jobs report
+     *
+     * @return array<string, mixed>
+     */
+    public function failedJobsReport(int $limit = 100): array;
+}

--- a/src/Services/Contracts/HealthCheckServiceContract.php
+++ b/src/Services/Contracts/HealthCheckServiceContract.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+use Illuminate\Database\Connection;
+
+interface HealthCheckServiceContract
+{
+    /**
+     * Perform comprehensive health check
+     *
+     * @return array{status: string, checks: array<string, array<string, mixed>>}
+     */
+    public function check(): array;
+
+    /**
+     * Check production readiness configuration.
+     *
+     * @return array{status: string, checks: array<string, array<string, mixed>>, timestamp: string}
+     */
+    public function readiness(): array;
+
+    /**
+     * Resolve the physical name of the monitor jobs table on a connection.
+     *
+     * Schema and query builders apply the connection's own table prefix
+     * (database.connections.*.prefix) automatically, but raw lookups against
+     * information_schema do not — so it must be prepended to the package's
+     * configured table prefix here.
+     */
+    public function monitorJobsTable(Connection $database): string;
+
+    /**
+     * Get overall health score (0-100)
+     */
+    public function getHealthScore(): int;
+
+    /**
+     * Check if system is healthy
+     */
+    public function isHealthy(): bool;
+}

--- a/src/Services/Contracts/InfrastructureServiceContract.php
+++ b/src/Services/Contracts/InfrastructureServiceContract.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+interface InfrastructureServiceContract
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getWorkerData(): array;
+
+    /**
+     * Breakdown of job processing by worker type (horizon, autoscale, queue_work) per queue.
+     * Shows which manager handles which queue and relative workload distribution.
+     *
+     * @return array<string, mixed>
+     */
+    public function getWorkerTypeBreakdown(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getQueueInfraData(): array;
+
+    /**
+     * SLA compliance per queue, using autoscale config targets when available.
+     * Falls back to a default 30s target if autoscale is not configured.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSlaData(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getScalingData(): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCapacityData(): array;
+
+    /**
+     * Cluster orchestration data for v3 autoscale. Returns null when not available.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getClusterData(): ?array;
+
+    /**
+     * Live cluster state from autoscale v3 Redis heartbeats.
+     * Returns real-time per-host resource data when available.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getLiveClusterState(): ?array;
+
+    /**
+     * Scaling decisions for one queue in chronological order, for the
+     * dashboard's scaling timeline chart, plus the worker range observed
+     * in the window.
+     *
+     * @return array{
+     *     events: array<int, array{t: string, current_workers: int, target_workers: int, action: string, reason: string}>,
+     *     worker_range: array{min: int|null, max: int|null}
+     * }
+     */
+    public function getScalingTimeline(string $queue, int $minutes = 60): array;
+}

--- a/src/Services/Contracts/WorkerContextServiceContract.php
+++ b/src/Services/Contracts/WorkerContextServiceContract.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Services\Contracts;
+
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerContextData;
+
+interface WorkerContextServiceContract
+{
+    /**
+     * Capture current worker context
+     */
+    public function capture(): WorkerContextData;
+
+    /**
+     * Get a unique identifier for the current worker
+     */
+    public function getUniqueIdentifier(): string;
+}

--- a/src/Services/DashboardCacheService.php
+++ b/src/Services/DashboardCacheService.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services;
 
+use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 
-final class DashboardCacheService
+final class DashboardCacheService implements DashboardCacheServiceContract
 {
     public function scopedKey(string $key): string
     {

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -9,8 +9,9 @@ use Cbox\LaravelQueueMonitor\Actions\Analytics\CalculateQueueHealthAction;
 use Cbox\LaravelQueueMonitor\Actions\Analytics\CalculateServerStatisticsAction;
 use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
+use Cbox\LaravelQueueMonitor\Services\Contracts\ExportServiceContract;
 
-final readonly class ExportService
+final readonly class ExportService implements ExportServiceContract
 {
     public function __construct(
         private JobMonitorRepositoryContract $repository,

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -7,12 +7,13 @@ namespace Cbox\LaravelQueueMonitor\Services;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
-final class HealthCheckService
+final class HealthCheckService implements HealthCheckServiceContract
 {
     /**
      * Perform comprehensive health check

--- a/src/Services/InfrastructureService.php
+++ b/src/Services/InfrastructureService.php
@@ -7,6 +7,7 @@ namespace Cbox\LaravelQueueMonitor\Services;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\ClusterEvent;
 use Cbox\LaravelQueueMonitor\Models\ScalingEvent;
+use Cbox\LaravelQueueMonitor\Services\Contracts\InfrastructureServiceContract;
 use Cbox\LaravelQueueMonitor\Utilities\DatabaseExpressionHelper;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
@@ -16,7 +17,7 @@ use Illuminate\Support\Facades\Schema;
  * Provides infrastructure query methods for worker utilization, queue capacity,
  * SLA compliance, and scaling data used by the health dashboard.
  */
-final class InfrastructureService
+final class InfrastructureService implements InfrastructureServiceContract
 {
     /**
      * @return array<string, mixed>

--- a/src/Services/WorkerContextService.php
+++ b/src/Services/WorkerContextService.php
@@ -8,8 +8,9 @@ use Cbox\LaravelQueueMetrics\DataTransferObjects\HorizonContext;
 use Cbox\LaravelQueueMetrics\Utilities\HorizonDetector;
 use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerContextData;
 use Cbox\LaravelQueueMonitor\Enums\WorkerType;
+use Cbox\LaravelQueueMonitor\Services\Contracts\WorkerContextServiceContract;
 
-final readonly class WorkerContextService
+final readonly class WorkerContextService implements WorkerContextServiceContract
 {
     private ?HorizonContext $horizonContext;
 

--- a/src/Utilities/PayloadRedactor.php
+++ b/src/Utilities/PayloadRedactor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Utilities;
 
-class PayloadRedactor
+final class PayloadRedactor
 {
     /**
      * Mask sensitive values in the payload array

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -3,3 +3,30 @@
 arch('it will not use debugging functions')
     ->expect(['dd', 'dump', 'ray'])
     ->each->not->toBeUsed();
+
+// Final-by-default: the domain concretes are sealed so behaviour is changed by
+// rebinding a contract, never by subclassing an implementation. Models, Commands,
+// and Http controllers are omitted because they extend framework base classes;
+// Contracts is omitted because it holds interfaces, which cannot be final.
+arch('domain classes are final by default')
+    ->expect([
+        'Cbox\LaravelQueueMonitor\Services',
+        'Cbox\LaravelQueueMonitor\Actions',
+        'Cbox\LaravelQueueMonitor\DataTransferObjects',
+        'Cbox\LaravelQueueMonitor\Support',
+        'Cbox\LaravelQueueMonitor\Utilities',
+        'Cbox\LaravelQueueMonitor\Listeners',
+        'Cbox\LaravelQueueMonitor\Repositories\Eloquent',
+        'Cbox\LaravelQueueMonitor\Events',
+        'Cbox\LaravelQueueMonitor\Exceptions',
+    ])
+    ->toBeFinal()
+    // Contracts is a sub-namespace of Services and holds interfaces, which can
+    // never be final; it is asserted separately by "service contracts are interfaces".
+    ->ignoring('Cbox\LaravelQueueMonitor\Services\Contracts');
+
+// Every domain service is resolved through a contract, so the interfaces must
+// actually exist as interfaces for a host to bind a replacement against them.
+arch('service contracts are interfaces')
+    ->expect('Cbox\LaravelQueueMonitor\Services\Contracts')
+    ->toBeInterfaces();


### PR DESCRIPTION
Second batch of the architecture campaign — the openness work. The package was contracts-first for repositories but the six service classes were unbound final concretes, so a host could neither override nor fake them. This closes the largest contracts-first gap and locks the sealing policy into CI.

## Service contracts
- Extracted a `<Service>Contract` interface for each of the six services (`Alerting`, `HealthCheck`, `Infrastructure`, `Export`, `DashboardCache`, `WorkerContext`) under `src/Services/Contracts/`, declaring every public method with its exact array-shape PHPDoc. Concretes stay `final` and now `implements` their contract.
- Bound via a new `services` config map, registered by `registerServices()` mirroring the existing `registerRepositories()` idiom — so a host overrides or fakes any service by rebinding its contract, exactly like the repositories.
- Retyped every injection site (controllers, commands, the two Eloquent repositories, the record-path actions, the cache-busting listeners) to depend on the contract, never the concrete.

## Openness arch test
- `tests/ArchTest.php` now asserts **final-by-default** across the domain namespaces (Services, Actions, DTOs, Support, Utilities, Listeners, Eloquent repositories, Events, Exceptions), so the build fails if someone seals or unseals against the policy by habit. Models, Commands, and Http are excluded (they extend framework base classes); the Contracts sub-namespace is excluded and separately asserted to be interfaces.
- Sealing surfaced two internal concretes that were the only non-final classes in the asserted namespaces — `PayloadRedactor` and `ScalingEventListener` — now `final` (nothing extends them). No genuinely-open class needed an `ignoring()` entry.

The package's extension model is now uniform: behaviour changes by **rebinding a contract**, never by subclassing an implementation.

Gate: pint, PHPStan level 9, Pest (548 passed, incl. the new arch assertions). Next: collapsing the three parallel read paths (UI/API/CLI), approached as shared assembly services so the API's response shapes don't change.