### PR TITLE
refactor(arch): single-source the health-score formula (campaign batch C)

### DIFF
--- a/src/Http/Controllers/DashboardHealthController.php
+++ b/src/Http/Controllers/DashboardHealthController.php
@@ -35,10 +35,8 @@ class DashboardHealthController extends Controller
         $healthCheck = $this->healthService->check();
         $alerts = $this->alertingService->checkAlertConditions();
 
-        // Derive score from already-computed checks to avoid running health queries twice
-        $checks = $healthCheck['checks'];
-        $healthyCount = collect($checks)->filter(fn (array $c): bool => (bool) ($c['healthy'] ?? false))->count();
-        $score = (int) round(($healthyCount / max(count($checks), 1)) * 100);
+        // Score from the checks we already ran, rather than running them again.
+        $score = $this->healthService->scoreFromChecks($healthCheck['checks']);
 
         return response()->json([
             'score' => $score,

--- a/src/Services/Contracts/HealthCheckServiceContract.php
+++ b/src/Services/Contracts/HealthCheckServiceContract.php
@@ -38,6 +38,13 @@ interface HealthCheckServiceContract
     public function getHealthScore(): int;
 
     /**
+     * Compute the health score (0-100) from an already-run set of checks.
+     *
+     * @param  array<string, array<string, mixed>>  $checks
+     */
+    public function scoreFromChecks(array $checks): int;
+
+    /**
      * Check if system is healthy
      */
     public function isHealthy(): bool;

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -309,13 +309,21 @@ final class HealthCheckService implements HealthCheckServiceContract
      */
     public function getHealthScore(): int
     {
-        $check = $this->check();
-        $checks = $check['checks'];
+        return $this->scoreFromChecks($this->check()['checks']);
+    }
 
+    /**
+     * Compute the health score (0-100) from an already-run set of checks, so a
+     * caller that already holds the checks (the dashboard) does not run them
+     * again to score them.
+     *
+     * @param  array<string, array<string, mixed>>  $checks
+     */
+    public function scoreFromChecks(array $checks): int
+    {
         $healthyCount = collect($checks)->filter(fn (array $c): bool => (bool) ($c['healthy'] ?? false))->count();
-        $totalChecks = count($checks);
 
-        return (int) round(($healthyCount / $totalChecks) * 100);
+        return (int) round(($healthyCount / max(count($checks), 1)) * 100);
     }
 
     /**

--- a/tests/Feature/Services/HealthCheckServiceTest.php
+++ b/tests/Feature/Services/HealthCheckServiceTest.php
@@ -64,6 +64,19 @@ test('health score calculation works', function () {
     expect($score)->toBeLessThanOrEqual(100);
 });
 
+test('the health score is single-sourced: getHealthScore and scoreFromChecks agree', function () {
+    JobMonitor::factory()->count(5)->create();
+
+    $service = app(HealthCheckService::class);
+    $checks = $service->check()['checks'];
+
+    expect($service->scoreFromChecks($checks))->toBe($service->getHealthScore());
+});
+
+test('scoreFromChecks guards against an empty check set', function () {
+    expect(app(HealthCheckService::class)->scoreFromChecks([]))->toBe(0);
+});
+
 test('isHealthy returns correct boolean', function () {
     JobMonitor::factory()->count(5)->create();
 


### PR DESCRIPTION
Third batch of the architecture campaign — the read-path deduplication, done surgically.

## What changed
The health score was computed by an identical formula in two places: `HealthCheckService::getHealthScore()` and `DashboardHealthController::health()`, which inlined it to avoid running the checks a second time. `HealthCheckService` now exposes `scoreFromChecks(array $checks)`, used by both `getHealthScore()` and the dashboard — the formula lives once, and the dashboard still scores the checks it already ran without re-running them. The shared version keeps the div-by-zero guard the service copy was missing.

## Scope — an honest note on the "three parallel read paths" finding
The review flagged three data paths served by parallel code (jobs list, statistics, health). Only the health-score duplication is safe to collapse without a breaking change:
- **Jobs list** and **statistics** return *intentionally different shapes* for the REST API (`JobMonitorResource`, with `flags`/`server`/`exception` object) and the dashboard UI (`JobMonitorTransformer`, with `server_name`/`error` string). Collapsing them onto one shape would break API consumers, so they stay distinct by design — the shared work already lives in the repositories and the `Calculate*` actions.
- The TUI command formats for the terminal, so its assembly isn't true output duplication.

This batch removes the one duplication that changes no output shape. Tests: the two score methods agree, and `scoreFromChecks([])` guards the empty set. Gate: pint, PHPStan level 9, Pest (550 passed).

That leaves batch D (typed read models) — the large one — which I'll checkpoint before starting.