### PR TITLE
refactor(arch): typed value objects for the service read paths (campaign batch D2+D3)

### DIFF
--- a/src/Commands/HealthCheckCommand.php
+++ b/src/Commands/HealthCheckCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Commands;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\HealthCheckResult;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ReadinessResult;
 use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
 use Cbox\LaravelQueueMonitor\Services\Contracts\HealthCheckServiceContract;
 use Illuminate\Console\Command;
@@ -27,7 +29,7 @@ class HealthCheckCommand extends Command
             $readiness = $healthCheck->readiness();
             // The exit code reflects the check outcome regardless of output
             // format — the --json path is exactly what CI/deploy gates script.
-            $exit = $readiness['status'] === 'ready' ? self::SUCCESS : self::FAILURE;
+            $exit = $readiness->status === 'ready' ? self::SUCCESS : self::FAILURE;
 
             if ($this->option('json')) {
                 $json = json_encode($readiness, JSON_PRETTY_PRINT);
@@ -42,7 +44,7 @@ class HealthCheckCommand extends Command
         }
 
         $health = $healthCheck->check();
-        $exit = $health['status'] === 'healthy' ? self::SUCCESS : self::FAILURE;
+        $exit = $health->status === 'healthy' ? self::SUCCESS : self::FAILURE;
 
         if ($this->option('json')) {
             $json = json_encode($health, JSON_PRETTY_PRINT);
@@ -58,19 +60,17 @@ class HealthCheckCommand extends Command
 
     /**
      * Display health status in table format
-     *
-     * @param  array{status: string, checks: array<string, array<string, mixed>>}  $health
      */
-    private function displayHealthStatus(array $health): void
+    private function displayHealthStatus(HealthCheckResult $health): void
     {
-        $statusIcon = $health['status'] === 'healthy' ? '✅' : '⚠️';
+        $statusIcon = $health->status === 'healthy' ? '✅' : '⚠️';
 
-        $this->info("{$statusIcon} System Status: ".strtoupper($health['status']));
+        $this->info("{$statusIcon} System Status: ".strtoupper($health->status));
         $this->newLine();
 
         $rows = [];
 
-        foreach ($health['checks'] as $name => $check) {
+        foreach ($health->checks as $name => $check) {
             /** @var bool $isHealthy */
             $isHealthy = $check['healthy'];
             $icon = $isHealthy ? '✅' : '❌';
@@ -88,17 +88,15 @@ class HealthCheckCommand extends Command
 
     /**
      * Display readiness status in table format
-     *
-     * @param  array{status: string, checks: array<string, array<string, mixed>>}  $readiness
      */
-    private function displayReadinessStatus(array $readiness): void
+    private function displayReadinessStatus(ReadinessResult $readiness): void
     {
-        $this->info('Production Readiness: '.strtoupper($readiness['status']));
+        $this->info('Production Readiness: '.strtoupper($readiness->status));
         $this->newLine();
 
         $rows = [];
 
-        foreach ($readiness['checks'] as $name => $check) {
+        foreach ($readiness->checks as $name => $check) {
             /** @var bool $isHealthy */
             $isHealthy = $check['healthy'];
             /** @var string $message */
@@ -131,7 +129,7 @@ class HealthCheckCommand extends Command
 
         $rows = [];
         foreach ($alerts as $name => $alert) {
-            $icon = match ($alert['severity']) {
+            $icon = match ($alert->severity) {
                 'critical' => '🔴',
                 'warning' => '🟡',
                 'info' => '🔵',
@@ -141,8 +139,8 @@ class HealthCheckCommand extends Command
             $rows[] = [
                 $icon,
                 ucwords(str_replace('_', ' ', $name)),
-                $alert['severity'],
-                $alert['message'],
+                $alert->severity,
+                $alert->message,
             ];
         }
 

--- a/src/Commands/QueueMonitorDashboardCommand.php
+++ b/src/Commands/QueueMonitorDashboardCommand.php
@@ -517,7 +517,10 @@ class QueueMonitorDashboardCommand extends Command
 
             try {
                 $alertingService = app(AlertingServiceContract::class);
-                $this->alertsData = $alertingService->checkAlertConditions();
+                $this->alertsData = array_map(
+                    static fn ($alert): array => $alert->toArray(),
+                    $alertingService->checkAlertConditions(),
+                );
             } catch (\Throwable) {
                 $this->alertsData = [];
             }
@@ -537,7 +540,7 @@ class QueueMonitorDashboardCommand extends Command
         if ($this->currentView === 4 && ($this->healthData === null || $now - $this->healthLastFetched > 10)) {
             try {
                 $healthService = app(HealthCheckServiceContract::class);
-                $this->healthData = $healthService->check();
+                $this->healthData = $healthService->check()->toArray();
                 $this->healthData['score'] = $healthService->getHealthScore();
                 $this->healthLastFetched = $now;
             } catch (\Throwable) {
@@ -565,11 +568,11 @@ class QueueMonitorDashboardCommand extends Command
             try {
                 $infraService = app(InfrastructureServiceContract::class);
                 $this->infrastructureData = [
-                    'workers' => $infraService->getWorkerData(),
-                    'worker_types' => $infraService->getWorkerTypeBreakdown(),
-                    'sla' => $infraService->getSlaData(),
-                    'scaling' => $infraService->getScalingData(),
-                    'capacity' => $infraService->getCapacityData(),
+                    'workers' => $infraService->getWorkerData()->toArray(),
+                    'worker_types' => $infraService->getWorkerTypeBreakdown()->toArray(),
+                    'sla' => $infraService->getSlaData()->toArray(),
+                    'scaling' => $infraService->getScalingData()->toArray(),
+                    'capacity' => $infraService->getCapacityData()->toArray(),
                 ];
                 $this->infraLastFetched = $now;
             } catch (\Throwable) {

--- a/src/DataTransferObjects/AlertEntry.php
+++ b/src/DataTransferObjects/AlertEntry.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * A single alert row: its severity, a human-readable message, and the count of
+ * affected jobs. Alerts are returned keyed by alert name (stuck_jobs,
+ * high_error_rate, and so on).
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class AlertEntry implements Arrayable, ArrayAccess, JsonSerializable
+{
+    public function __construct(
+        public string $severity,
+        public string $message,
+        public int $count,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $severity = $data['severity'] ?? '';
+        $message = $data['message'] ?? '';
+        $count = $data['count'] ?? 0;
+
+        return new self(
+            severity: is_scalar($severity) ? (string) $severity : '',
+            message: is_scalar($message) ? (string) $message : '',
+            count: is_numeric($count) ? (int) $count : 0,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'severity' => $this->severity,
+            'message' => $this->message,
+            'count' => $this->count,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+}

--- a/src/DataTransferObjects/CapacityData.php
+++ b/src/DataTransferObjects/CapacityData.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Per-queue throughput capacity: measured max jobs/minute against the observed
+ * peak, with the resulting headroom and status.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class CapacityData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `queues` stays an array of rows rather than a nested value object: each
+     * row's `max_jobs_per_minute` and `headroom_percent` are int-or-float (a
+     * bare `0` when there is no data, a rounded float otherwise), and reproducing
+     * that `0` vs `0.0` distinction byte-for-byte is safest by passing the built
+     * rows straight through.
+     *
+     * @param  array<int, array<string, mixed>>  $queues
+     */
+    public function __construct(
+        public array $queues = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            queues: self::rows($data['queues'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'queues' => $this->queues,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/DataTransferObjects/ClusterData.php
+++ b/src/DataTransferObjects/ClusterData.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Cluster orchestration picture for the autoscale v3 tab: topology, the latest
+ * scaling signal, leadership stability, and the recent event histories. Built
+ * only when cluster events exist; the service returns null otherwise.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class ClusterData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `topology`, `scalingSignal` and `leadership` are single derived summaries
+     * and the three histories are cluster-event dumps, all kept as arrays: they
+     * are assembled from raw ClusterEvent rows whose columns vary by event type.
+     *
+     * @param  array<string, mixed>  $topology
+     * @param  array<string, mixed>|null  $scalingSignal
+     * @param  array<string, mixed>  $leadership
+     * @param  array<int, array<string, mixed>>  $signalHistory
+     * @param  array<int, array<string, mixed>>  $leaderHistory
+     * @param  array<int, array<string, mixed>>  $managerEvents
+     */
+    public function __construct(
+        public bool $hasCluster,
+        public ?int $autoscaleVersion,
+        public array $topology,
+        public ?array $scalingSignal,
+        public array $leadership,
+        public array $signalHistory = [],
+        public array $leaderHistory = [],
+        public array $managerEvents = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $version = $data['autoscale_version'] ?? null;
+
+        return new self(
+            hasCluster: (bool) ($data['has_cluster'] ?? false),
+            autoscaleVersion: is_numeric($version) ? (int) $version : null,
+            topology: self::assoc($data['topology'] ?? null),
+            scalingSignal: is_array($data['scaling_signal'] ?? null) ? self::assoc($data['scaling_signal']) : null,
+            leadership: self::assoc($data['leadership'] ?? null),
+            signalHistory: self::rows($data['signal_history'] ?? null),
+            leaderHistory: self::rows($data['leader_history'] ?? null),
+            managerEvents: self::rows($data['manager_events'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'has_cluster' => $this->hasCluster,
+            'autoscale_version' => $this->autoscaleVersion,
+            'topology' => $this->topology,
+            'scaling_signal' => $this->scalingSignal,
+            'leadership' => $this->leadership,
+            'signal_history' => $this->signalHistory,
+            'leader_history' => $this->leaderHistory,
+            'manager_events' => $this->managerEvents,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $rows[] = self::assoc($row);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function assoc(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[(string) $key] = $item;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/DataTransferObjects/FailedJobsReport.php
+++ b/src/DataTransferObjects/FailedJobsReport.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Exported failed-jobs report: the total, the failures grouped by exception and
+ * by queue, and a sample of the most recent failures.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class FailedJobsReport implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * The groupings stay arrays: `byException` and `byQueue` are keyed by
+     * arbitrary exception classes and queue names discovered at runtime, and
+     * `recentFailures` is a sampled row list.
+     *
+     * @param  array<string, array<string, mixed>>  $byException
+     * @param  array<string, int>  $byQueue
+     * @param  array<int, array<string, mixed>>  $recentFailures
+     */
+    public function __construct(
+        public string $generatedAt,
+        public int $totalFailed,
+        public array $byException = [],
+        public array $byQueue = [],
+        public array $recentFailures = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $generatedAt = $data['generated_at'] ?? '';
+        $totalFailed = $data['total_failed'] ?? 0;
+
+        return new self(
+            generatedAt: is_scalar($generatedAt) ? (string) $generatedAt : '',
+            totalFailed: is_numeric($totalFailed) ? (int) $totalFailed : 0,
+            byException: self::map($data['by_exception'] ?? null),
+            byQueue: self::intMap($data['by_queue'] ?? null),
+            recentFailures: self::rows($data['recent_failures'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'generated_at' => $this->generatedAt,
+            'total_failed' => $this->totalFailed,
+            'by_exception' => $this->byException,
+            'by_queue' => $this->byQueue,
+            'recent_failures' => $this->recentFailures,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $rows[] = self::assoc($row);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function map(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $key => $row) {
+            if (is_array($row)) {
+                $out[(string) $key] = self::assoc($row);
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private static function intMap(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $key => $item) {
+            if (is_numeric($item)) {
+                $out[(string) $key] = (int) $item;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function assoc(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[(string) $key] = $item;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/DataTransferObjects/HealthCheckResult.php
+++ b/src/DataTransferObjects/HealthCheckResult.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Outcome of a comprehensive health check: the overall status, the individual
+ * check results keyed by name, and when it ran.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class HealthCheckResult implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `checks` stays a keyed map of check rows: each row carries a healthy flag
+     * and a message, plus an optional `details` payload whose contents differ
+     * per check (stuck-job lists, storage sizes, middleware lists).
+     *
+     * @param  array<string, array<string, mixed>>  $checks
+     */
+    public function __construct(
+        public string $status,
+        public array $checks,
+        public string $timestamp,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $status = $data['status'] ?? '';
+        $timestamp = $data['timestamp'] ?? '';
+
+        return new self(
+            status: is_scalar($status) ? (string) $status : '',
+            checks: self::map($data['checks'] ?? null),
+            timestamp: is_scalar($timestamp) ? (string) $timestamp : '',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'checks' => $this->checks,
+            'timestamp' => $this->timestamp,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function map(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $key => $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $rowKey => $item) {
+                    $normalized[(string) $rowKey] = $item;
+                }
+                $out[(string) $key] = $normalized;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/DataTransferObjects/LiveClusterState.php
+++ b/src/DataTransferObjects/LiveClusterState.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Live cluster state read from the autoscale package's Redis heartbeat summary:
+ * fleet totals plus the per-host and per-workload rows. Built only when the
+ * autoscale facade is present and reports a cluster; the service returns null
+ * otherwise.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class LiveClusterState implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * The scalar totals are `mixed` and `hosts`/`workloads` stay arrays: every
+     * value here is copied straight from the autoscale package's heartbeat
+     * summary, an external blob the monitor only reshapes and forwards.
+     *
+     * @param  array<int, array<string, mixed>>  $hosts
+     * @param  array<int, array<string, mixed>>  $workloads
+     */
+    public function __construct(
+        public mixed $clusterId,
+        public mixed $leaderId,
+        public mixed $managerCount,
+        public mixed $totalWorkers,
+        public mixed $requiredWorkers,
+        public mixed $totalWorkerCapacity,
+        public mixed $utilizationPercent,
+        public mixed $scaleSignal,
+        public mixed $generatedAt,
+        public array $hosts = [],
+        public array $workloads = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            clusterId: $data['cluster_id'] ?? null,
+            leaderId: $data['leader_id'] ?? null,
+            managerCount: $data['manager_count'] ?? null,
+            totalWorkers: $data['total_workers'] ?? null,
+            requiredWorkers: $data['required_workers'] ?? null,
+            totalWorkerCapacity: $data['total_worker_capacity'] ?? null,
+            utilizationPercent: $data['utilization_percent'] ?? null,
+            scaleSignal: $data['scale_signal'] ?? null,
+            generatedAt: $data['generated_at'] ?? null,
+            hosts: self::rows($data['hosts'] ?? null),
+            workloads: self::rows($data['workloads'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'cluster_id' => $this->clusterId,
+            'leader_id' => $this->leaderId,
+            'manager_count' => $this->managerCount,
+            'total_workers' => $this->totalWorkers,
+            'required_workers' => $this->requiredWorkers,
+            'total_worker_capacity' => $this->totalWorkerCapacity,
+            'utilization_percent' => $this->utilizationPercent,
+            'scale_signal' => $this->scaleSignal,
+            'generated_at' => $this->generatedAt,
+            'hosts' => $this->hosts,
+            'workloads' => $this->workloads,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/DataTransferObjects/QueueInfraData.php
+++ b/src/DataTransferObjects/QueueInfraData.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Per-queue infrastructure metrics sourced from the queue-metrics package.
+ * Collapses to a single `available => false` key when that package is absent
+ * or its query fails, exactly as the raw array did.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class QueueInfraData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `queues` stays an array: each row is external queue-metrics telemetry
+     * assembled from that package's own variable response shape.
+     *
+     * @param  array<int, array<string, mixed>>  $queues
+     */
+    public function __construct(
+        public bool $available,
+        public array $queues = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (! (bool) ($data['available'] ?? false)) {
+            return new self(false);
+        }
+
+        return new self(
+            available: true,
+            queues: self::rows($data['queues'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if (! $this->available) {
+            return ['available' => false];
+        }
+
+        return [
+            'available' => true,
+            'queues' => $this->queues,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/DataTransferObjects/ReadinessResult.php
+++ b/src/DataTransferObjects/ReadinessResult.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Outcome of the production-readiness check: the overall status, the individual
+ * readiness checks keyed by name, and when it ran.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class ReadinessResult implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `checks` stays a keyed map of check rows: each row carries a healthy flag
+     * and a message, plus an optional `details` payload whose contents differ
+     * per check (middleware lists, retention limits, timeout pairs).
+     *
+     * @param  array<string, array<string, mixed>>  $checks
+     */
+    public function __construct(
+        public string $status,
+        public array $checks,
+        public string $timestamp,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $status = $data['status'] ?? '';
+        $timestamp = $data['timestamp'] ?? '';
+
+        return new self(
+            status: is_scalar($status) ? (string) $status : '',
+            checks: self::map($data['checks'] ?? null),
+            timestamp: is_scalar($timestamp) ? (string) $timestamp : '',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'checks' => $this->checks,
+            'timestamp' => $this->timestamp,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function map(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($value as $key => $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $rowKey => $item) {
+                    $normalized[(string) $rowKey] = $item;
+                }
+                $out[(string) $key] = $normalized;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/DataTransferObjects/ScalingData.php
+++ b/src/DataTransferObjects/ScalingData.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Worker-utilization and autoscaling picture for the infrastructure and
+ * autoscale tabs: the utilization summary, the recent scaling-decision history
+ * and its aggregate summary, the fuses currently holding queues, and breach
+ * severity.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class ScalingData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `history` and `openFuses` are scaling-event dumps and `summary`/
+     * `utilization`/`breachSeverity` are aggregates whose keys depend on which
+     * actions occurred in the window, so they stay arrays rather than forcing a
+     * fixed nested shape onto variable telemetry.
+     *
+     * @param  array<string, mixed>  $utilization
+     * @param  array<int, array<string, mixed>>  $history
+     * @param  array<string, mixed>  $summary
+     * @param  array<int, array<string, mixed>>  $openFuses
+     * @param  array<string, mixed>|null  $breachSeverity
+     */
+    public function __construct(
+        public array $utilization,
+        public array $history = [],
+        public array $summary = [],
+        public array $openFuses = [],
+        public bool $hasAutoscale = false,
+        public ?int $autoscaleVersion = null,
+        public ?array $breachSeverity = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $version = $data['autoscale_version'] ?? null;
+
+        return new self(
+            utilization: self::assoc($data['utilization'] ?? null),
+            history: self::rows($data['history'] ?? null),
+            summary: self::assoc($data['summary'] ?? null),
+            openFuses: self::rows($data['open_fuses'] ?? null),
+            hasAutoscale: (bool) ($data['has_autoscale'] ?? false),
+            autoscaleVersion: is_numeric($version) ? (int) $version : null,
+            breachSeverity: is_array($data['breach_severity'] ?? null) ? self::assoc($data['breach_severity']) : null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'utilization' => $this->utilization,
+            'history' => $this->history,
+            'summary' => $this->summary,
+            'open_fuses' => $this->openFuses,
+            'has_autoscale' => $this->hasAutoscale,
+            'autoscale_version' => $this->autoscaleVersion,
+            'breach_severity' => $this->breachSeverity,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $rows[] = self::assoc($row);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function assoc(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[(string) $key] = $item;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/DataTransferObjects/ScalingTimeline.php
+++ b/src/DataTransferObjects/ScalingTimeline.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * One queue's scaling decisions over a window, in chronological order, plus the
+ * worker range observed across them — the data behind the autoscale timeline
+ * chart.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class ScalingTimeline implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `events` stays a list of scaling-decision rows drawn from ScalingEvent
+     * records.
+     *
+     * @param  array<int, array<string, mixed>>  $events
+     * @param  array{min: int|null, max: int|null}  $workerRange
+     */
+    public function __construct(
+        public array $events = [],
+        public array $workerRange = ['min' => null, 'max' => null],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $range = $data['worker_range'] ?? [];
+        $range = is_array($range) ? $range : [];
+
+        return new self(
+            events: self::rows($data['events'] ?? null),
+            workerRange: [
+                'min' => self::intOrNull($range, 'min'),
+                'max' => self::intOrNull($range, 'max'),
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'events' => $this->events,
+            'worker_range' => $this->workerRange,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $data
+     */
+    private static function intOrNull(array $data, string $key): ?int
+    {
+        $value = $data[$key] ?? null;
+
+        return is_numeric($value) ? (int) $value : null;
+    }
+}

--- a/src/DataTransferObjects/SlaData.php
+++ b/src/DataTransferObjects/SlaData.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * SLA compliance across queues: the per-queue rows plus where the targets came
+ * from (autoscale config or the built-in default).
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class SlaData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * @param  array<int, SlaQueueCompliance>  $perQueue
+     */
+    public function __construct(
+        public bool $available,
+        public array $perQueue = [],
+        public string $source = 'default',
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $rows = [];
+        $rawRows = $data['per_queue'] ?? null;
+        if (is_array($rawRows)) {
+            foreach ($rawRows as $row) {
+                if (is_array($row)) {
+                    $normalized = [];
+                    foreach ($row as $key => $value) {
+                        $normalized[(string) $key] = $value;
+                    }
+                    $rows[] = SlaQueueCompliance::fromArray($normalized);
+                }
+            }
+        }
+
+        $source = $data['source'] ?? 'default';
+
+        return new self(
+            available: (bool) ($data['available'] ?? false),
+            perQueue: $rows,
+            source: is_scalar($source) ? (string) $source : 'default',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'available' => $this->available,
+            'per_queue' => array_map(
+                static fn (SlaQueueCompliance $row): array => $row->toArray(),
+                $this->perQueue,
+            ),
+            'source' => $this->source,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+}

--- a/src/DataTransferObjects/SlaQueueCompliance.php
+++ b/src/DataTransferObjects/SlaQueueCompliance.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * One queue's SLA compliance over the window: its pickup-time target and how
+ * many jobs met it. A fixed, domain-owned shape, so it is a value object rather
+ * than a bare array row.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class SlaQueueCompliance implements Arrayable, ArrayAccess, JsonSerializable
+{
+    public function __construct(
+        public string $queue,
+        public int $targetSeconds,
+        public float $compliance,
+        public int $total,
+        public int $within,
+        public int $breached,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $queue = $data['queue'] ?? '';
+        $compliance = $data['compliance'] ?? 0;
+
+        return new self(
+            queue: is_scalar($queue) ? (string) $queue : '',
+            targetSeconds: self::intFrom($data, 'target_seconds'),
+            compliance: is_numeric($compliance) ? (float) $compliance : 0.0,
+            total: self::intFrom($data, 'total'),
+            within: self::intFrom($data, 'within'),
+            breached: self::intFrom($data, 'breached'),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'queue' => $this->queue,
+            'target_seconds' => $this->targetSeconds,
+            'compliance' => $this->compliance,
+            'total' => $this->total,
+            'within' => $this->within,
+            'breached' => $this->breached,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private static function intFrom(array $data, string $key): int
+    {
+        $value = $data[$key] ?? null;
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+}

--- a/src/DataTransferObjects/StatisticsReport.php
+++ b/src/DataTransferObjects/StatisticsReport.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Exported statistics report: a timestamp plus the global, per-server, and
+ * per-queue-health sections as computed by the analytics actions.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class StatisticsReport implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * The three sections stay arrays: they are the analytics actions' own
+     * already-serialized output (each already a value object flattened to an
+     * array), forwarded verbatim into the report.
+     *
+     * @param  array<string, mixed>  $global
+     * @param  array<int, array<string, mixed>>  $servers
+     * @param  array<int, array<string, mixed>>  $queueHealth
+     */
+    public function __construct(
+        public string $generatedAt,
+        public array $global = [],
+        public array $servers = [],
+        public array $queueHealth = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $generatedAt = $data['generated_at'] ?? '';
+
+        return new self(
+            generatedAt: is_scalar($generatedAt) ? (string) $generatedAt : '',
+            global: self::assoc($data['global'] ?? null),
+            servers: self::rows($data['servers'] ?? null),
+            queueHealth: self::rows($data['queue_health'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'generated_at' => $this->generatedAt,
+            'global' => $this->global,
+            'servers' => $this->servers,
+            'queue_health' => $this->queueHealth,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $rows[] = self::assoc($row);
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function assoc(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[(string) $key] = $item;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/DataTransferObjects/WorkerData.php
+++ b/src/DataTransferObjects/WorkerData.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Horizon worker utilization: process totals and the live supervisor/workload
+ * blobs. Collapses to a single `available => false` key when Horizon is absent
+ * or unreadable, exactly as the raw array did.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class WorkerData implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * `supervisors` and `workload` stay arrays: they are Horizon telemetry blobs
+     * whose shape the monitor does not own, and `jobsPerMinute` is whatever the
+     * metrics repository returns for the current driver.
+     *
+     * @param  array<int, array<string, mixed>>  $supervisors
+     * @param  array<int, array<string, mixed>>  $workload
+     */
+    public function __construct(
+        public bool $available,
+        public ?int $totalProcesses = null,
+        public array $supervisors = [],
+        public array $workload = [],
+        public mixed $jobsPerMinute = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (! (bool) ($data['available'] ?? false)) {
+            return new self(false);
+        }
+
+        $totalProcesses = $data['total_processes'] ?? null;
+
+        return new self(
+            available: true,
+            totalProcesses: is_numeric($totalProcesses) ? (int) $totalProcesses : null,
+            supervisors: self::rows($data['supervisors'] ?? null),
+            workload: self::rows($data['workload'] ?? null),
+            jobsPerMinute: $data['jobs_per_minute'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if (! $this->available) {
+            return ['available' => false];
+        }
+
+        return [
+            'available' => true,
+            'total_processes' => $this->totalProcesses,
+            'supervisors' => $this->supervisors,
+            'workload' => $this->workload,
+            'jobs_per_minute' => $this->jobsPerMinute,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/DataTransferObjects/WorkerTypeBreakdown.php
+++ b/src/DataTransferObjects/WorkerTypeBreakdown.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\DataTransferObjects;
+
+use ArrayAccess;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * Job processing broken down by worker type (Horizon, autoscale, queue worker):
+ * the per-type aggregate rows and the per-queue rows behind them.
+ *
+ * @implements Arrayable<string, mixed>
+ * @implements ArrayAccess<string, mixed>
+ */
+final readonly class WorkerTypeBreakdown implements Arrayable, ArrayAccess, JsonSerializable
+{
+    /**
+     * Both collections stay arrays: their rows are aggregation output whose
+     * columns vary with the grouped worker types present, not a fixed shape.
+     *
+     * @param  array<int, array<string, mixed>>  $byType
+     * @param  array<int, array<string, mixed>>  $perQueue
+     */
+    public function __construct(
+        public array $byType = [],
+        public array $perQueue = [],
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            byType: self::rows($data['by_type'] ?? null),
+            perQueue: self::rows($data['per_queue'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'by_type' => $this->byType,
+            'per_queue' => $this->perQueue,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->toArray());
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->toArray()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException(self::class.' is immutable.');
+    }
+
+    /**
+     * Normalise a raw list of associative rows into a typed list, dropping any
+     * non-array entries so the reconstructed shape matches what is emitted.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($value as $row) {
+            if (is_array($row)) {
+                $normalized = [];
+                foreach ($row as $key => $item) {
+                    $normalized[(string) $key] = $item;
+                }
+                $rows[] = $normalized;
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/src/Http/Controllers/DashboardHealthController.php
+++ b/src/Http/Controllers/DashboardHealthController.php
@@ -36,12 +36,12 @@ class DashboardHealthController extends Controller
         $alerts = $this->alertingService->checkAlertConditions();
 
         // Score from the checks we already ran, rather than running them again.
-        $score = $this->healthService->scoreFromChecks($healthCheck['checks']);
+        $score = $this->healthService->scoreFromChecks($healthCheck->checks);
 
         return response()->json([
             'score' => $score,
-            'status' => $healthCheck['status'],
-            'checks' => $healthCheck['checks'],
+            'status' => $healthCheck->status,
+            'checks' => $healthCheck->checks,
             'alerts' => $alerts,
         ]);
     }
@@ -57,7 +57,7 @@ class DashboardHealthController extends Controller
             'queues' => $this->infrastructureService->getQueueInfraData(),
             'sla' => $this->infrastructureService->getSlaData(),
             'scaling' => array_intersect_key(
-                $this->infrastructureService->getScalingData(),
+                $this->infrastructureService->getScalingData()->toArray(),
                 array_flip(['utilization', 'breach_severity']),
             ),
             'capacity' => $this->infrastructureService->getCapacityData(),
@@ -81,7 +81,7 @@ class DashboardHealthController extends Controller
             'cluster' => $cluster,
             'live' => $live,
             'sla' => $this->infrastructureService->getSlaData(),
-            'available' => ($scaling['has_autoscale'] ?? false) || (is_array($cluster) && ($cluster['has_cluster'] ?? false)) || $live !== null,
+            'available' => $scaling->hasAutoscale || ($cluster !== null && $cluster->hasCluster) || $live !== null,
         ]);
     }
 
@@ -114,8 +114,8 @@ class DashboardHealthController extends Controller
             'buckets' => $timeline->buckets,
             'live' => $timeline->live,
             'memory_limit_mb' => $timeline->memoryLimitMb,
-            'workers' => $scaling['events'],
-            'worker_range' => $scaling['worker_range'],
+            'workers' => $scaling->events,
+            'worker_range' => $scaling->workerRange,
         ]);
     }
 }

--- a/src/Http/Controllers/HealthCheckController.php
+++ b/src/Http/Controllers/HealthCheckController.php
@@ -23,7 +23,7 @@ class HealthCheckController extends Controller
     {
         $health = $this->healthCheck->check();
 
-        $status = $health['status'] === 'healthy' ? 200 : 503;
+        $status = $health->status === 'healthy' ? 200 : 503;
 
         return response()->json($health, $status);
     }

--- a/src/Services/AlertingService.php
+++ b/src/Services/AlertingService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\AlertEntry;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Services\Contracts\AlertingServiceContract;
@@ -14,7 +15,7 @@ final class AlertingService implements AlertingServiceContract
     /**
      * Check for alert conditions
      *
-     * @return array<string, array{severity: string, message: string, count: int}>
+     * @return array<string, AlertEntry>
      */
     public function checkAlertConditions(): array
     {
@@ -31,11 +32,11 @@ final class AlertingService implements AlertingServiceContract
         // Check for stuck jobs
         $stuck = QueryBuilderHelper::stuck($stuckMinutes)->count();
         if ($stuck > 0) {
-            $alerts['stuck_jobs'] = [
-                'severity' => 'warning',
-                'message' => "{$stuck} jobs stuck in processing for > {$stuckMinutes} minutes",
-                'count' => $stuck,
-            ];
+            $alerts['stuck_jobs'] = new AlertEntry(
+                severity: 'warning',
+                message: "{$stuck} jobs stuck in processing for > {$stuckMinutes} minutes",
+                count: $stuck,
+            );
         }
 
         // Check error rate
@@ -44,27 +45,27 @@ final class AlertingService implements AlertingServiceContract
         $errorRate = $recentTotal > 0 ? ($recentFailed / $recentTotal) * 100 : 0;
 
         if ($errorRate > $errorCritical) {
-            $alerts['high_error_rate'] = [
-                'severity' => 'critical',
-                'message' => sprintf('Error rate %.2f%% exceeds threshold (%s%%)', $errorRate, rtrim(rtrim(sprintf('%.1f', $errorCritical), '0'), '.')),
-                'count' => $recentFailed,
-            ];
+            $alerts['high_error_rate'] = new AlertEntry(
+                severity: 'critical',
+                message: sprintf('Error rate %.2f%% exceeds threshold (%s%%)', $errorRate, rtrim(rtrim(sprintf('%.1f', $errorCritical), '0'), '.')),
+                count: $recentFailed,
+            );
         } elseif ($errorRate > $errorWarn) {
-            $alerts['elevated_error_rate'] = [
-                'severity' => 'warning',
-                'message' => sprintf('Error rate %.2f%% elevated (threshold: %s%%)', $errorRate, rtrim(rtrim(sprintf('%.1f', $errorWarn), '0'), '.')),
-                'count' => $recentFailed,
-            ];
+            $alerts['elevated_error_rate'] = new AlertEntry(
+                severity: 'warning',
+                message: sprintf('Error rate %.2f%% elevated (threshold: %s%%)', $errorRate, rtrim(rtrim(sprintf('%.1f', $errorWarn), '0'), '.')),
+                count: $recentFailed,
+            );
         }
 
         // Check for high backlog
         $queued = JobMonitor::where('status', JobStatus::QUEUED)->count();
         if ($queued > $backlogThreshold) {
-            $alerts['high_backlog'] = [
-                'severity' => 'warning',
-                'message' => "{$queued} jobs queued (threshold: {$backlogThreshold})",
-                'count' => $queued,
-            ];
+            $alerts['high_backlog'] = new AlertEntry(
+                severity: 'warning',
+                message: "{$queued} jobs queued (threshold: {$backlogThreshold})",
+                count: $queued,
+            );
         }
 
         // Check for slow jobs
@@ -73,11 +74,11 @@ final class AlertingService implements AlertingServiceContract
             ->count();
 
         if ($slowJobs > 10) {
-            $alerts['slow_jobs'] = [
-                'severity' => 'info',
-                'message' => "{$slowJobs} jobs took > 30 seconds today",
-                'count' => $slowJobs,
-            ];
+            $alerts['slow_jobs'] = new AlertEntry(
+                severity: 'info',
+                message: "{$slowJobs} jobs took > 30 seconds today",
+                count: $slowJobs,
+            );
         }
 
         return $alerts;
@@ -86,16 +87,13 @@ final class AlertingService implements AlertingServiceContract
     /**
      * Get critical alerts only
      *
-     * @return array<string, array{severity: string, message: string, count: int}>
+     * @return array<string, AlertEntry>
      */
     public function getCriticalAlerts(): array
     {
-        /** @var array<string, array{severity: string, message: string, count: int}> $alerts */
-        $alerts = collect($this->checkAlertConditions())
-            ->filter(fn ($alert) => $alert['severity'] === 'critical')
+        return collect($this->checkAlertConditions())
+            ->filter(fn (AlertEntry $alert): bool => $alert->severity === 'critical')
             ->all();
-
-        return $alerts;
     }
 
     /**

--- a/src/Services/Contracts/AlertingServiceContract.php
+++ b/src/Services/Contracts/AlertingServiceContract.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services\Contracts;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\AlertEntry;
+
 interface AlertingServiceContract
 {
     /**
      * Check for alert conditions
      *
-     * @return array<string, array{severity: string, message: string, count: int}>
+     * @return array<string, AlertEntry>
      */
     public function checkAlertConditions(): array;
 
     /**
      * Get critical alerts only
      *
-     * @return array<string, array{severity: string, message: string, count: int}>
+     * @return array<string, AlertEntry>
      */
     public function getCriticalAlerts(): array;
 

--- a/src/Services/Contracts/ExportServiceContract.php
+++ b/src/Services/Contracts/ExportServiceContract.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services\Contracts;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\FailedJobsReport;
 use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\StatisticsReport;
 
 interface ExportServiceContract
 {
@@ -22,15 +24,11 @@ interface ExportServiceContract
 
     /**
      * Export statistics report
-     *
-     * @return array<string, mixed>
      */
-    public function statisticsReport(): array;
+    public function statisticsReport(): StatisticsReport;
 
     /**
      * Export failed jobs report
-     *
-     * @return array<string, mixed>
      */
-    public function failedJobsReport(int $limit = 100): array;
+    public function failedJobsReport(int $limit = 100): FailedJobsReport;
 }

--- a/src/Services/Contracts/HealthCheckServiceContract.php
+++ b/src/Services/Contracts/HealthCheckServiceContract.php
@@ -4,23 +4,21 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services\Contracts;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\HealthCheckResult;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ReadinessResult;
 use Illuminate\Database\Connection;
 
 interface HealthCheckServiceContract
 {
     /**
      * Perform comprehensive health check
-     *
-     * @return array{status: string, checks: array<string, array<string, mixed>>}
      */
-    public function check(): array;
+    public function check(): HealthCheckResult;
 
     /**
      * Check production readiness configuration.
-     *
-     * @return array{status: string, checks: array<string, array<string, mixed>>, timestamp: string}
      */
-    public function readiness(): array;
+    public function readiness(): ReadinessResult;
 
     /**
      * Resolve the physical name of the monitor jobs table on a connection.

--- a/src/Services/Contracts/InfrastructureServiceContract.php
+++ b/src/Services/Contracts/InfrastructureServiceContract.php
@@ -4,68 +4,53 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services\Contracts;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\CapacityData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ClusterData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\LiveClusterState;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\QueueInfraData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingTimeline;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\SlaData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerTypeBreakdown;
+
 interface InfrastructureServiceContract
 {
-    /**
-     * @return array<string, mixed>
-     */
-    public function getWorkerData(): array;
+    public function getWorkerData(): WorkerData;
 
     /**
      * Breakdown of job processing by worker type (horizon, autoscale, queue_work) per queue.
      * Shows which manager handles which queue and relative workload distribution.
-     *
-     * @return array<string, mixed>
      */
-    public function getWorkerTypeBreakdown(): array;
+    public function getWorkerTypeBreakdown(): WorkerTypeBreakdown;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getQueueInfraData(): array;
+    public function getQueueInfraData(): QueueInfraData;
 
     /**
      * SLA compliance per queue, using autoscale config targets when available.
      * Falls back to a default 30s target if autoscale is not configured.
-     *
-     * @return array<string, mixed>
      */
-    public function getSlaData(): array;
+    public function getSlaData(): SlaData;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getScalingData(): array;
+    public function getScalingData(): ScalingData;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getCapacityData(): array;
+    public function getCapacityData(): CapacityData;
 
     /**
      * Cluster orchestration data for v3 autoscale. Returns null when not available.
-     *
-     * @return array<string, mixed>|null
      */
-    public function getClusterData(): ?array;
+    public function getClusterData(): ?ClusterData;
 
     /**
      * Live cluster state from autoscale v3 Redis heartbeats.
      * Returns real-time per-host resource data when available.
-     *
-     * @return array<string, mixed>|null
      */
-    public function getLiveClusterState(): ?array;
+    public function getLiveClusterState(): ?LiveClusterState;
 
     /**
      * Scaling decisions for one queue in chronological order, for the
      * dashboard's scaling timeline chart, plus the worker range observed
      * in the window.
-     *
-     * @return array{
-     *     events: array<int, array{t: string, current_workers: int, target_workers: int, action: string, reason: string}>,
-     *     worker_range: array{min: int|null, max: int|null}
-     * }
      */
-    public function getScalingTimeline(string $queue, int $minutes = 60): array;
+    public function getScalingTimeline(string $queue, int $minutes = 60): ScalingTimeline;
 }

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -7,7 +7,9 @@ namespace Cbox\LaravelQueueMonitor\Services;
 use Cbox\LaravelQueueMonitor\Actions\Analytics\CalculateJobStatisticsAction;
 use Cbox\LaravelQueueMonitor\Actions\Analytics\CalculateQueueHealthAction;
 use Cbox\LaravelQueueMonitor\Actions\Analytics\CalculateServerStatisticsAction;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\FailedJobsReport;
 use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\StatisticsReport;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
 use Cbox\LaravelQueueMonitor\Services\Contracts\ExportServiceContract;
 
@@ -129,50 +131,50 @@ final readonly class ExportService implements ExportServiceContract
 
     /**
      * Export statistics report
-     *
-     * @return array<string, mixed>
      */
-    public function statisticsReport(): array
+    public function statisticsReport(): StatisticsReport
     {
-        return [
-            'generated_at' => now()->toIso8601String(),
-            'global' => $this->jobStatistics->execute(),
-            'servers' => $this->serverStatistics->execute(),
-            'queue_health' => $this->queueHealth->execute(),
-        ];
+        return new StatisticsReport(
+            generatedAt: now()->toIso8601String(),
+            global: $this->jobStatistics->execute(),
+            servers: $this->serverStatistics->execute(),
+            queueHealth: $this->queueHealth->execute(),
+        );
     }
 
     /**
      * Export failed jobs report
-     *
-     * @return array<string, mixed>
      */
-    public function failedJobsReport(int $limit = 100): array
+    public function failedJobsReport(int $limit = 100): FailedJobsReport
     {
         $failed = $this->repository->getFailedJobs($limit);
 
-        $byException = $failed->groupBy('exception_class')
-            ->map(fn ($jobs) => [
+        $byException = [];
+        foreach ($failed->groupBy('exception_class') as $exceptionClass => $jobs) {
+            $byException[(string) $exceptionClass] = [
                 'count' => $jobs->count(),
-                'jobs' => $jobs->pluck('uuid')->toArray(),
-            ])
-            ->toArray();
+                'jobs' => $jobs->pluck('uuid')->all(),
+            ];
+        }
 
-        $byQueue = $failed->groupBy('queue')
-            ->map(fn ($jobs) => $jobs->count())
-            ->toArray();
+        $byQueue = [];
+        foreach ($failed->groupBy('queue') as $queue => $jobs) {
+            $byQueue[(string) $queue] = $jobs->count();
+        }
 
-        return [
-            'generated_at' => now()->toIso8601String(),
-            'total_failed' => $failed->count(),
-            'by_exception' => $byException,
-            'by_queue' => $byQueue,
-            'recent_failures' => $failed->take(10)->map(fn ($job) => [
-                'uuid' => $job->uuid,
-                'job_class' => $job->job_class,
-                'exception' => $job->exception_class,
-                'failed_at' => $job->completed_at?->toIso8601String(),
-            ])->toArray(),
-        ];
+        $recentFailures = $failed->take(10)->map(fn ($job): array => [
+            'uuid' => $job->uuid,
+            'job_class' => $job->job_class,
+            'exception' => $job->exception_class,
+            'failed_at' => $job->completed_at?->toIso8601String(),
+        ])->values()->all();
+
+        return new FailedJobsReport(
+            generatedAt: now()->toIso8601String(),
+            totalFailed: $failed->count(),
+            byException: $byException,
+            byQueue: $byQueue,
+            recentFailures: $recentFailures,
+        );
     }
 }

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\HealthCheckResult;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ReadinessResult;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\LaravelQueueMonitor;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
@@ -17,16 +19,14 @@ final class HealthCheckService implements HealthCheckServiceContract
 {
     /**
      * Perform comprehensive health check
-     *
-     * @return array{status: string, checks: array<string, array<string, mixed>>}
      */
-    public function check(): array
+    public function check(): HealthCheckResult
     {
         /** @var string $cachePrefix */
         $cachePrefix = config('queue-monitor.cache.prefix', 'queue_monitor_');
 
         if (config('queue-monitor.cache.enabled', true)) {
-            /** @var array{status: string, checks: array<string, array<string, mixed>>}|null $cached */
+            /** @var HealthCheckResult|null $cached */
             $cached = Cache::get($cachePrefix.'health_check');
             if ($cached !== null) {
                 return $cached;
@@ -44,11 +44,11 @@ final class HealthCheckService implements HealthCheckServiceContract
 
         $healthy = collect($checks)->every(fn ($check) => $check['healthy']);
 
-        $result = [
-            'status' => $healthy ? 'healthy' : 'degraded',
-            'checks' => $checks,
-            'timestamp' => now()->toIso8601String(),
-        ];
+        $result = new HealthCheckResult(
+            status: $healthy ? 'healthy' : 'degraded',
+            checks: $checks,
+            timestamp: now()->toIso8601String(),
+        );
 
         if (config('queue-monitor.cache.enabled', true)) {
             Cache::put($cachePrefix.'health_check', $result, 15);
@@ -59,10 +59,8 @@ final class HealthCheckService implements HealthCheckServiceContract
 
     /**
      * Check production readiness configuration.
-     *
-     * @return array{status: string, checks: array<string, array<string, mixed>>, timestamp: string}
      */
-    public function readiness(): array
+    public function readiness(): ReadinessResult
     {
         $checks = [
             'access_control' => $this->checkAccessControlReadiness(),
@@ -74,11 +72,11 @@ final class HealthCheckService implements HealthCheckServiceContract
 
         $ready = collect($checks)->every(fn (array $check): bool => (bool) $check['healthy']);
 
-        return [
-            'status' => $ready ? 'ready' : 'attention',
-            'checks' => $checks,
-            'timestamp' => now()->toIso8601String(),
-        ];
+        return new ReadinessResult(
+            status: $ready ? 'ready' : 'attention',
+            checks: $checks,
+            timestamp: now()->toIso8601String(),
+        );
     }
 
     /**
@@ -309,7 +307,7 @@ final class HealthCheckService implements HealthCheckServiceContract
      */
     public function getHealthScore(): int
     {
-        return $this->scoreFromChecks($this->check()['checks']);
+        return $this->scoreFromChecks($this->check()->checks);
     }
 
     /**
@@ -331,7 +329,7 @@ final class HealthCheckService implements HealthCheckServiceContract
      */
     public function isHealthy(): bool
     {
-        return $this->check()['status'] === 'healthy';
+        return $this->check()->status === 'healthy';
     }
 
     /**

--- a/src/Services/InfrastructureService.php
+++ b/src/Services/InfrastructureService.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Services;
 
+use Cbox\LaravelQueueMonitor\DataTransferObjects\CapacityData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ClusterData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\LiveClusterState;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\QueueInfraData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingTimeline;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\SlaData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\SlaQueueCompliance;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerTypeBreakdown;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\ClusterEvent;
 use Cbox\LaravelQueueMonitor\Models\ScalingEvent;
@@ -19,13 +29,10 @@ use Illuminate\Support\Facades\Schema;
  */
 final class InfrastructureService implements InfrastructureServiceContract
 {
-    /**
-     * @return array<string, mixed>
-     */
-    public function getWorkerData(): array
+    public function getWorkerData(): WorkerData
     {
         if (! class_exists('Laravel\Horizon\Horizon')) {
-            return ['available' => false];
+            return new WorkerData(false);
         }
 
         try {
@@ -56,32 +63,32 @@ final class InfrastructureService implements InfrastructureServiceContract
                 ];
             }
 
-            return [
-                'available' => true,
-                'total_processes' => $totalProcesses,
-                'supervisors' => $supervisorData,
-                'workload' => collect($workload)->map(fn (array $w) => [
-                    'queue' => $w['name'],
-                    'length' => $w['length'],
-                    'wait' => $w['wait'],
-                    'processes' => $w['processes'],
-                ])->values()->all(),
-                'jobs_per_minute' => $metricsRepo->jobsProcessedPerMinute(),
-            ];
+            $workloadData = collect($workload)->map(fn (array $w) => [
+                'queue' => $w['name'],
+                'length' => $w['length'],
+                'wait' => $w['wait'],
+                'processes' => $w['processes'],
+            ])->values()->all();
+
+            return new WorkerData(
+                available: true,
+                totalProcesses: $totalProcesses,
+                supervisors: $supervisorData,
+                workload: $workloadData,
+                jobsPerMinute: $metricsRepo->jobsProcessedPerMinute(),
+            );
         } catch (\Throwable $e) {
             report($e);
 
-            return ['available' => false];
+            return new WorkerData(false);
         }
     }
 
     /**
      * Breakdown of job processing by worker type (horizon, autoscale, queue_work) per queue.
      * Shows which manager handles which queue and relative workload distribution.
-     *
-     * @return array<string, mixed>
      */
-    public function getWorkerTypeBreakdown(): array
+    public function getWorkerTypeBreakdown(): WorkerTypeBreakdown
     {
         // Per worker_type + queue: job count, avg duration, failure rate
         /** @var array<int, array<string, mixed>> $breakdown */
@@ -135,19 +142,16 @@ final class InfrastructureService implements InfrastructureServiceContract
             ];
         })->values()->all();
 
-        return [
-            'by_type' => $byType,
-            'per_queue' => $breakdown,
-        ];
+        return new WorkerTypeBreakdown(
+            byType: $byType,
+            perQueue: $breakdown,
+        );
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getQueueInfraData(): array
+    public function getQueueInfraData(): QueueInfraData
     {
         if (! class_exists('Cbox\LaravelQueueMetrics\Services\QueueMetricsQueryService')) {
-            return ['available' => false];
+            return new QueueInfraData(false);
         }
 
         try {
@@ -155,44 +159,44 @@ final class InfrastructureService implements InfrastructureServiceContract
             /** @var array<int, array<string, mixed>> $queues */
             $queues = $service->getAllQueuesWithMetrics();
 
-            return [
-                'available' => true,
-                'queues' => collect($queues)->map(function (array $q): array {
-                    /** @var array<string, mixed>|null $health */
-                    $health = $q['health'] ?? null;
+            $queueRows = collect($queues)->map(function (array $q): array {
+                /** @var array<string, mixed>|null $health */
+                $health = $q['health'] ?? null;
 
-                    return [
-                        'connection' => $q['connection'] ?? null,
-                        'queue' => $q['queue'] ?? $q['name'] ?? 'unknown',
-                        'depth' => is_array($q['depth'] ?? 0) ? ($q['depth']['total'] ?? 0) : ($q['depth'] ?? 0),
-                        'pending' => $q['pending'] ?? 0,
-                        'scheduled' => $q['scheduled'] ?? 0,
-                        'reserved' => $q['reserved'] ?? 0,
-                        'active_workers' => $q['active_workers'] ?? 0,
-                        'throughput_per_minute' => $q['throughput_per_minute'] ?? 0,
-                        'avg_duration_ms' => $q['avg_duration_ms'] ?? $q['avgDuration'] ?? null,
-                        'failure_rate' => $q['failure_rate'] ?? $q['failureRate'] ?? 0,
-                        'utilization_rate' => $q['utilization_rate'] ?? $q['utilizationRate'] ?? 0,
-                        'oldest_job_age' => $q['oldest_job_age'] ?? $q['oldestJobAge'] ?? 0,
-                        'health_status' => (is_array($health) ? ($health['status'] ?? null) : null) ?? $q['ageStatus'] ?? 'unknown',
-                        'health_score' => is_array($health) ? ($health['score'] ?? 0) : 0,
-                    ];
-                })->values()->all(),
-            ];
+                return [
+                    'connection' => $q['connection'] ?? null,
+                    'queue' => $q['queue'] ?? $q['name'] ?? 'unknown',
+                    'depth' => is_array($q['depth'] ?? 0) ? ($q['depth']['total'] ?? 0) : ($q['depth'] ?? 0),
+                    'pending' => $q['pending'] ?? 0,
+                    'scheduled' => $q['scheduled'] ?? 0,
+                    'reserved' => $q['reserved'] ?? 0,
+                    'active_workers' => $q['active_workers'] ?? 0,
+                    'throughput_per_minute' => $q['throughput_per_minute'] ?? 0,
+                    'avg_duration_ms' => $q['avg_duration_ms'] ?? $q['avgDuration'] ?? null,
+                    'failure_rate' => $q['failure_rate'] ?? $q['failureRate'] ?? 0,
+                    'utilization_rate' => $q['utilization_rate'] ?? $q['utilizationRate'] ?? 0,
+                    'oldest_job_age' => $q['oldest_job_age'] ?? $q['oldestJobAge'] ?? 0,
+                    'health_status' => (is_array($health) ? ($health['status'] ?? null) : null) ?? $q['ageStatus'] ?? 'unknown',
+                    'health_score' => is_array($health) ? ($health['score'] ?? 0) : 0,
+                ];
+            })->values()->all();
+
+            return new QueueInfraData(
+                available: true,
+                queues: $queueRows,
+            );
         } catch (\Throwable $e) {
             report($e);
 
-            return ['available' => false];
+            return new QueueInfraData(false);
         }
     }
 
     /**
      * SLA compliance per queue, using autoscale config targets when available.
      * Falls back to a default 30s target if autoscale is not configured.
-     *
-     * @return array<string, mixed>
      */
-    public function getSlaData(): array
+    public function getSlaData(): SlaData
     {
         $driver = $this->databaseDriver();
 
@@ -243,7 +247,11 @@ final class InfrastructureService implements InfrastructureServiceContract
             ->get();
 
         if ($rows->isEmpty()) {
-            return ['available' => true, 'per_queue' => [], 'source' => empty($slaTargets) ? 'default' : 'autoscale'];
+            return new SlaData(
+                available: true,
+                perQueue: [],
+                source: empty($slaTargets) ? 'default' : 'autoscale',
+            );
         }
 
         $perQueue = [];
@@ -266,11 +274,21 @@ final class InfrastructureService implements InfrastructureServiceContract
         // Sort by compliance ascending (worst first)
         usort($perQueue, fn ($a, $b) => $a['compliance'] <=> $b['compliance']);
 
-        return [
-            'available' => true,
-            'per_queue' => $perQueue,
-            'source' => empty($slaTargets) ? 'default' : 'autoscale',
-        ];
+        return new SlaData(
+            available: true,
+            perQueue: array_map(
+                static fn (array $row): SlaQueueCompliance => new SlaQueueCompliance(
+                    queue: (string) $row['queue'],
+                    targetSeconds: (int) $row['target_seconds'],
+                    compliance: (float) $row['compliance'],
+                    total: (int) $row['total'],
+                    within: (int) $row['within'],
+                    breached: (int) $row['breached'],
+                ),
+                $perQueue,
+            ),
+            source: empty($slaTargets) ? 'default' : 'autoscale',
+        );
     }
 
     /**
@@ -303,10 +321,7 @@ final class InfrastructureService implements InfrastructureServiceContract
         return $targets;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getScalingData(): array
+    public function getScalingData(): ScalingData
     {
         /** @var string $prefix */
         $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
@@ -407,8 +422,8 @@ final class InfrastructureService implements InfrastructureServiceContract
             }
         }
 
-        return [
-            'utilization' => [
+        return new ScalingData(
+            utilization: [
                 'percentage' => $utilization,
                 'total_processing_ms' => $totalProcessingMs,
                 'busy_workers' => $busyWorkers,
@@ -416,19 +431,16 @@ final class InfrastructureService implements InfrastructureServiceContract
                 'window_seconds' => 3600,
                 'status' => $utilization > 85 ? 'overloaded' : ($utilization > 60 ? 'optimal' : ($utilization > 30 ? 'underutilized' : 'idle')),
             ],
-            'history' => $scalingHistory,
-            'summary' => $scalingSummary,
-            'open_fuses' => $openFuses,
-            'has_autoscale' => $hasScalingTable && count($scalingHistory) > 0,
-            'autoscale_version' => $this->detectAutoscaleVersion(),
-            'breach_severity' => $breachSeverity ?? null,
-        ];
+            history: $scalingHistory,
+            summary: $scalingSummary,
+            openFuses: $openFuses,
+            hasAutoscale: $hasScalingTable && count($scalingHistory) > 0,
+            autoscaleVersion: $this->detectAutoscaleVersion(),
+            breachSeverity: $breachSeverity ?? null,
+        );
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getCapacityData(): array
+    public function getCapacityData(): CapacityData
     {
         $dateFormat = DatabaseExpressionHelper::minuteBucket('queued_at', $this->databaseDriver());
 
@@ -479,15 +491,13 @@ final class InfrastructureService implements InfrastructureServiceContract
             ];
         }
 
-        return ['queues' => $capacity];
+        return new CapacityData(queues: $capacity);
     }
 
     /**
      * Cluster orchestration data for v3 autoscale. Returns null when not available.
-     *
-     * @return array<string, mixed>|null
      */
-    public function getClusterData(): ?array
+    public function getClusterData(): ?ClusterData
     {
         /** @var string|null $dbConnection */
         $dbConnection = config('queue-monitor.database.connection');
@@ -632,16 +642,16 @@ final class InfrastructureService implements InfrastructureServiceContract
                 ])
                 ->all();
 
-            return [
-                'has_cluster' => true,
-                'autoscale_version' => $this->detectAutoscaleVersion() ?? 3,
-                'topology' => [
+            return new ClusterData(
+                hasCluster: true,
+                autoscaleVersion: $this->detectAutoscaleVersion() ?? 3,
+                topology: [
                     'cluster_id' => $clusterId,
                     'leader_id' => $leaderId,
                     'active_managers' => $activeManagers,
                     'host_count' => count($activeManagers),
                 ],
-                'scaling_signal' => $latestSignal ? [
+                scalingSignal: $latestSignal ? [
                     'current_hosts' => $latestSignal->current_hosts,
                     'recommended_hosts' => $latestSignal->recommended_hosts,
                     'current_capacity' => $latestSignal->current_capacity,
@@ -650,17 +660,17 @@ final class InfrastructureService implements InfrastructureServiceContract
                     'reason' => $latestSignal->reason,
                     'updated_at' => $latestSignal->created_at?->toIso8601String(),
                 ] : null,
-                'leadership' => [
+                leadership: [
                     'unstable' => $leadershipFlag !== null,
                     'changes_in_window' => $changesInWindow,
                     'window_seconds' => $leadershipWindow,
                     'reason' => $leadershipFlag?->reason,
                     'flagged_at' => $leadershipFlag?->created_at?->toIso8601String(),
                 ],
-                'signal_history' => $signalHistory,
-                'leader_history' => $leaderHistory,
-                'manager_events' => $managerEvents,
-            ];
+                signalHistory: $signalHistory,
+                leaderHistory: $leaderHistory,
+                managerEvents: $managerEvents,
+            );
         } catch (\Throwable $e) {
             report($e);
 
@@ -671,10 +681,8 @@ final class InfrastructureService implements InfrastructureServiceContract
     /**
      * Live cluster state from autoscale v3 Redis heartbeats.
      * Returns real-time per-host resource data when available.
-     *
-     * @return array<string, mixed>|null
      */
-    public function getLiveClusterState(): ?array
+    public function getLiveClusterState(): ?LiveClusterState
     {
         if (! class_exists('Cbox\\LaravelQueueAutoscale\\Facades\\LaravelQueueAutoscale')) {
             return null;
@@ -694,54 +702,58 @@ final class InfrastructureService implements InfrastructureServiceContract
             /** @var array<int, array<string, mixed>> $workloads */
             $workloads = $summary['workloads'] ?? [];
 
-            return [
-                'cluster_id' => $summary['cluster_id'] ?? null,
-                'leader_id' => $summary['leader_id'] ?? null,
-                'manager_count' => $summary['manager_count'] ?? 0,
-                'total_workers' => $summary['total_workers'] ?? 0,
-                'required_workers' => $summary['required_workers'] ?? 0,
-                'total_worker_capacity' => $summary['total_worker_capacity'] ?? 0,
-                'utilization_percent' => $summary['utilization_percent'] ?? 0,
-                'scale_signal' => $summary['scale_signal'] ?? null,
-                'generated_at' => $summary['generated_at'] ?? null,
-                'hosts' => collect($managers)->map(fn (array $m) => [
-                    'manager_id' => $m['manager_id'] ?? null,
-                    'host' => $m['host'] ?? null,
-                    'is_leader' => $m['is_leader'] ?? false,
-                    'total_workers' => $m['total_workers'] ?? 0,
-                    'max_workers' => $m['max_workers'] ?? 0,
-                    'available_worker_capacity' => $m['available_worker_capacity'] ?? 0,
-                    'capacity_limiter' => $m['capacity_limiter'] ?? null,
-                    'cpu_percent' => $m['cpu_percent'] ?? null,
-                    'cpu_cores' => $m['cpu_cores'] ?? null,
-                    'memory_percent' => $m['memory_percent'] ?? null,
-                    'memory_total_mb' => $m['memory_total_mb'] ?? null,
-                    'memory_used_mb' => $m['memory_used_mb'] ?? null,
-                    'memory_free_mb' => $m['memory_free_mb'] ?? null,
-                    'queue_count' => $m['queue_count'] ?? 0,
-                    'group_count' => $m['group_count'] ?? 0,
-                    'queue_workers' => $m['queue_workers'] ?? [],
-                    'package_version' => $m['package_version'] ?? null,
-                    'last_seen_human' => $m['last_seen_human'] ?? null,
-                ])->values()->all(),
-                'workloads' => collect($workloads)->map(fn (array $w) => [
-                    'type' => $w['type'] ?? 'queue',
-                    'connection' => $w['connection'] ?? null,
-                    'name' => $w['name'] ?? null,
-                    'current_workers' => $w['current_workers'] ?? 0,
-                    'target_workers' => $w['target_workers'] ?? 0,
-                    'worker_min' => $w['worker_min'] ?? 0,
-                    'worker_max' => $w['worker_max'] ?? 0,
-                    'sla_target_seconds' => $w['sla_target_seconds'] ?? null,
-                    'pending' => $w['pending'] ?? 0,
-                    'oldest_job_age' => $w['oldest_job_age'] ?? 0,
-                    'oldest_job_age_status' => $w['oldest_job_age_status'] ?? 'normal',
-                    'throughput_per_minute' => $w['throughput_per_minute'] ?? 0,
-                    'active_workers' => $w['active_workers'] ?? 0,
-                    'utilization_percent' => $w['utilization_percent'] ?? 0,
-                    'action' => $w['action'] ?? 'hold',
-                ])->values()->all(),
-            ];
+            $hostRows = collect($managers)->map(fn (array $m) => [
+                'manager_id' => $m['manager_id'] ?? null,
+                'host' => $m['host'] ?? null,
+                'is_leader' => $m['is_leader'] ?? false,
+                'total_workers' => $m['total_workers'] ?? 0,
+                'max_workers' => $m['max_workers'] ?? 0,
+                'available_worker_capacity' => $m['available_worker_capacity'] ?? 0,
+                'capacity_limiter' => $m['capacity_limiter'] ?? null,
+                'cpu_percent' => $m['cpu_percent'] ?? null,
+                'cpu_cores' => $m['cpu_cores'] ?? null,
+                'memory_percent' => $m['memory_percent'] ?? null,
+                'memory_total_mb' => $m['memory_total_mb'] ?? null,
+                'memory_used_mb' => $m['memory_used_mb'] ?? null,
+                'memory_free_mb' => $m['memory_free_mb'] ?? null,
+                'queue_count' => $m['queue_count'] ?? 0,
+                'group_count' => $m['group_count'] ?? 0,
+                'queue_workers' => $m['queue_workers'] ?? [],
+                'package_version' => $m['package_version'] ?? null,
+                'last_seen_human' => $m['last_seen_human'] ?? null,
+            ])->values()->all();
+
+            $workloadRows = collect($workloads)->map(fn (array $w) => [
+                'type' => $w['type'] ?? 'queue',
+                'connection' => $w['connection'] ?? null,
+                'name' => $w['name'] ?? null,
+                'current_workers' => $w['current_workers'] ?? 0,
+                'target_workers' => $w['target_workers'] ?? 0,
+                'worker_min' => $w['worker_min'] ?? 0,
+                'worker_max' => $w['worker_max'] ?? 0,
+                'sla_target_seconds' => $w['sla_target_seconds'] ?? null,
+                'pending' => $w['pending'] ?? 0,
+                'oldest_job_age' => $w['oldest_job_age'] ?? 0,
+                'oldest_job_age_status' => $w['oldest_job_age_status'] ?? 'normal',
+                'throughput_per_minute' => $w['throughput_per_minute'] ?? 0,
+                'active_workers' => $w['active_workers'] ?? 0,
+                'utilization_percent' => $w['utilization_percent'] ?? 0,
+                'action' => $w['action'] ?? 'hold',
+            ])->values()->all();
+
+            return new LiveClusterState(
+                clusterId: $summary['cluster_id'] ?? null,
+                leaderId: $summary['leader_id'] ?? null,
+                managerCount: $summary['manager_count'] ?? 0,
+                totalWorkers: $summary['total_workers'] ?? 0,
+                requiredWorkers: $summary['required_workers'] ?? 0,
+                totalWorkerCapacity: $summary['total_worker_capacity'] ?? 0,
+                utilizationPercent: $summary['utilization_percent'] ?? 0,
+                scaleSignal: $summary['scale_signal'] ?? null,
+                generatedAt: $summary['generated_at'] ?? null,
+                hosts: $hostRows,
+                workloads: $workloadRows,
+            );
         } catch (\Throwable $e) {
             report($e);
 
@@ -807,13 +819,8 @@ final class InfrastructureService implements InfrastructureServiceContract
      * Scaling decisions for one queue in chronological order, for the
      * dashboard's scaling timeline chart, plus the worker range observed
      * in the window.
-     *
-     * @return array{
-     *     events: array<int, array{t: string, current_workers: int, target_workers: int, action: string, reason: string}>,
-     *     worker_range: array{min: int|null, max: int|null}
-     * }
      */
-    public function getScalingTimeline(string $queue, int $minutes = 60): array
+    public function getScalingTimeline(string $queue, int $minutes = 60): ScalingTimeline
     {
         /** @var string $prefix */
         $prefix = config('queue-monitor.database.table_prefix', 'queue_monitor_');
@@ -821,7 +828,7 @@ final class InfrastructureService implements InfrastructureServiceContract
         $dbConnection = config('queue-monitor.database.connection');
 
         if (! Schema::connection($dbConnection)->hasTable($prefix.'scaling_events')) {
-            return ['events' => [], 'worker_range' => ['min' => null, 'max' => null]];
+            return new ScalingTimeline(events: [], workerRange: ['min' => null, 'max' => null]);
         }
 
         $events = ScalingEvent::query()
@@ -849,10 +856,10 @@ final class InfrastructureService implements InfrastructureServiceContract
             ];
         })->all();
 
-        return [
-            'events' => $series,
-            'worker_range' => ['min' => $min, 'max' => $max],
-        ];
+        return new ScalingTimeline(
+            events: $series,
+            workerRange: ['min' => $min, 'max' => $max],
+        );
     }
 
     private function intConfig(string $key, int $default): int

--- a/tests/Unit/DataTransferObjects/ServiceValueObjectsTest.php
+++ b/tests/Unit/DataTransferObjects/ServiceValueObjectsTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\DataTransferObjects\AlertEntry;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\CapacityData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ClusterData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\FailedJobsReport;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\HealthCheckResult;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\LiveClusterState;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\QueueInfraData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ReadinessResult;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\ScalingTimeline;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\SlaData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\SlaQueueCompliance;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\StatisticsReport;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerData;
+use Cbox\LaravelQueueMonitor\DataTransferObjects\WorkerTypeBreakdown;
+
+/**
+ * Representative arrays are written in the exact key order the concrete services
+ * emit, so the round-trip and json_encode assertions double as an edge-identity
+ * guard: the value objects must serialize byte-for-key like the arrays they
+ * replaced — including the int-vs-float distinction (a bare `0` versus `0.0`).
+ *
+ * @return array<string, array{class-string, array<string, mixed>}>
+ */
+dataset('service value objects', [
+    'WorkerData (unavailable)' => [
+        WorkerData::class,
+        ['available' => false],
+    ],
+    'WorkerData (available)' => [
+        WorkerData::class,
+        [
+            'available' => true,
+            'total_processes' => 6,
+            'supervisors' => [
+                ['name' => 'supervisor-1', 'status' => 'running', 'processes' => 6, 'queues' => ['default', 'high']],
+            ],
+            'workload' => [
+                ['queue' => 'default', 'length' => 3, 'wait' => 12, 'processes' => 2],
+            ],
+            'jobs_per_minute' => 42,
+        ],
+    ],
+    'WorkerTypeBreakdown' => [
+        WorkerTypeBreakdown::class,
+        [
+            'by_type' => [
+                ['type' => 'horizon', 'label' => 'Horizon', 'total_jobs' => 10, 'total_workers' => 2, 'queues' => ['default'], 'breakdown' => []],
+            ],
+            'per_queue' => [
+                ['worker_type' => 'horizon', 'queue' => 'default', 'total' => 10, 'completed' => 9, 'failed' => 1, 'success_rate' => 90.0, 'avg_duration_ms' => 120.0, 'unique_workers' => 2],
+            ],
+        ],
+    ],
+    'QueueInfraData (unavailable)' => [
+        QueueInfraData::class,
+        ['available' => false],
+    ],
+    'QueueInfraData (available)' => [
+        QueueInfraData::class,
+        [
+            'available' => true,
+            'queues' => [
+                ['connection' => 'redis', 'queue' => 'default', 'depth' => 5, 'pending' => 5, 'scheduled' => 0, 'reserved' => 0, 'active_workers' => 2, 'throughput_per_minute' => 30, 'avg_duration_ms' => 100, 'failure_rate' => 0, 'utilization_rate' => 50, 'oldest_job_age' => 3, 'health_status' => 'ok', 'health_score' => 100],
+            ],
+        ],
+    ],
+    'SlaQueueCompliance' => [
+        SlaQueueCompliance::class,
+        ['queue' => 'default', 'target_seconds' => 30, 'compliance' => 100.0, 'total' => 10, 'within' => 10, 'breached' => 0],
+    ],
+    'SlaData' => [
+        SlaData::class,
+        [
+            'available' => true,
+            'per_queue' => [
+                ['queue' => 'default', 'target_seconds' => 30, 'compliance' => 95.5, 'total' => 100, 'within' => 95, 'breached' => 5],
+            ],
+            'source' => 'autoscale',
+        ],
+    ],
+    'ScalingData' => [
+        ScalingData::class,
+        [
+            'utilization' => ['percentage' => 45.5, 'total_processing_ms' => 1000, 'busy_workers' => 2, 'total_workers' => 4, 'window_seconds' => 3600, 'status' => 'underutilized'],
+            'history' => [
+                ['queue' => 'default', 'action' => 'scale_up', 'current_workers' => 2, 'target_workers' => 4, 'reason' => 'load', 'time' => '2025-01-01T12:00:00+00:00', 'time_human' => '1 minute ago'],
+            ],
+            'summary' => ['total_decisions' => 5, 'scale_ups' => 3, 'scale_downs' => 2, 'sla_breaches' => 0, 'sla_recoveries' => 0, 'sla_breach_predictions' => 0, 'fuse_trips' => 0],
+            'open_fuses' => [
+                ['connection' => 'redis', 'queue' => 'webhooks', 'state' => 'tripped', 'held_at_workers' => 0, 'reason' => 'errors', 'since' => '2025-01-01T12:00:00+00:00', 'since_human' => '5 minutes ago'],
+            ],
+            'has_autoscale' => true,
+            'autoscale_version' => 3,
+            'breach_severity' => ['avg_breach_seconds' => 15.0, 'max_breach_percentage' => 50.0],
+        ],
+    ],
+    'ScalingData (no breach severity)' => [
+        ScalingData::class,
+        [
+            'utilization' => ['percentage' => 0, 'total_processing_ms' => 0, 'busy_workers' => 0, 'total_workers' => 1, 'window_seconds' => 3600, 'status' => 'idle'],
+            'history' => [],
+            'summary' => [],
+            'open_fuses' => [],
+            'has_autoscale' => false,
+            'autoscale_version' => null,
+            'breach_severity' => null,
+        ],
+    ],
+    'CapacityData' => [
+        CapacityData::class,
+        [
+            'queues' => [
+                ['queue' => 'default', 'avg_duration_ms' => 120.0, 'workers' => 2, 'max_jobs_per_minute' => 60.0, 'peak_jobs_per_minute' => 30, 'headroom_percent' => 50.0, 'status' => 'optimal'],
+            ],
+        ],
+    ],
+    'CapacityData (no-data row keeps int zeros)' => [
+        CapacityData::class,
+        [
+            'queues' => [
+                ['queue' => 'idle', 'avg_duration_ms' => 0.0, 'workers' => 0, 'max_jobs_per_minute' => 0, 'peak_jobs_per_minute' => 0, 'headroom_percent' => 0, 'status' => 'no_data'],
+            ],
+        ],
+    ],
+    'ClusterData' => [
+        ClusterData::class,
+        [
+            'has_cluster' => true,
+            'autoscale_version' => 3,
+            'topology' => [
+                'cluster_id' => 'c1',
+                'leader_id' => 'mgr-1',
+                'active_managers' => [
+                    ['manager_id' => 'mgr-1', 'host' => 'web-01', 'started_at' => null, 'started_at_human' => '1 minute ago'],
+                ],
+                'host_count' => 1,
+            ],
+            'scaling_signal' => ['current_hosts' => 3, 'recommended_hosts' => 5, 'current_capacity' => 15, 'required_workers' => 20, 'action' => 'scale_up', 'reason' => 'load', 'updated_at' => '2025-01-01T12:00:00+00:00'],
+            'leadership' => ['unstable' => false, 'changes_in_window' => 1, 'window_seconds' => 60, 'reason' => null, 'flagged_at' => null],
+            'signal_history' => [
+                ['current_hosts' => 3, 'recommended_hosts' => 5, 'current_capacity' => 15, 'required_workers' => 20, 'action' => 'scale_up', 'time' => '2025-01-01T12:00:00+00:00'],
+            ],
+            'leader_history' => [
+                ['leader_id' => 'mgr-1', 'previous_leader_id' => null, 'observed_by' => 'mgr-1', 'time' => '2025-01-01T12:00:00+00:00', 'time_human' => '1 minute ago'],
+            ],
+            'manager_events' => [
+                ['event_type' => 'manager_started', 'manager_id' => 'mgr-1', 'host' => 'web-01', 'reason' => null, 'meta' => ['started_at' => 123], 'time' => '2025-01-01T12:00:00+00:00', 'time_human' => '1 minute ago'],
+            ],
+        ],
+    ],
+    'ClusterData (no scaling signal)' => [
+        ClusterData::class,
+        [
+            'has_cluster' => true,
+            'autoscale_version' => 3,
+            'topology' => ['cluster_id' => 'c1', 'leader_id' => null, 'active_managers' => [], 'host_count' => 0],
+            'scaling_signal' => null,
+            'leadership' => ['unstable' => false, 'changes_in_window' => 0, 'window_seconds' => 60, 'reason' => null, 'flagged_at' => null],
+            'signal_history' => [],
+            'leader_history' => [],
+            'manager_events' => [],
+        ],
+    ],
+    'LiveClusterState' => [
+        LiveClusterState::class,
+        [
+            'cluster_id' => 'c1',
+            'leader_id' => 'mgr-1',
+            'manager_count' => 2,
+            'total_workers' => 10,
+            'required_workers' => 12,
+            'total_worker_capacity' => 20,
+            'utilization_percent' => 50,
+            'scale_signal' => 'scale_up',
+            'generated_at' => '2025-01-01T12:00:00+00:00',
+            'hosts' => [
+                ['manager_id' => 'mgr-1', 'host' => 'web-01', 'is_leader' => true, 'total_workers' => 5, 'max_workers' => 10, 'available_worker_capacity' => 5, 'capacity_limiter' => null, 'cpu_percent' => null, 'cpu_cores' => null, 'memory_percent' => null, 'memory_total_mb' => null, 'memory_used_mb' => null, 'memory_free_mb' => null, 'queue_count' => 2, 'group_count' => 1, 'queue_workers' => [], 'package_version' => null, 'last_seen_human' => null],
+            ],
+            'workloads' => [
+                ['type' => 'queue', 'connection' => 'redis', 'name' => 'default', 'current_workers' => 2, 'target_workers' => 3, 'worker_min' => 0, 'worker_max' => 10, 'sla_target_seconds' => null, 'pending' => 5, 'oldest_job_age' => 3, 'oldest_job_age_status' => 'normal', 'throughput_per_minute' => 30, 'active_workers' => 2, 'utilization_percent' => 50, 'action' => 'hold'],
+            ],
+        ],
+    ],
+    'ScalingTimeline' => [
+        ScalingTimeline::class,
+        [
+            'events' => [
+                ['t' => '2025-01-01T12:00:00+00:00', 'current_workers' => 2, 'target_workers' => 5, 'action' => 'scale_up', 'reason' => 'load'],
+            ],
+            'worker_range' => ['min' => 2, 'max' => 5],
+        ],
+    ],
+    'ScalingTimeline (empty)' => [
+        ScalingTimeline::class,
+        [
+            'events' => [],
+            'worker_range' => ['min' => null, 'max' => null],
+        ],
+    ],
+    'HealthCheckResult' => [
+        HealthCheckResult::class,
+        [
+            'status' => 'healthy',
+            'checks' => [
+                'database' => ['healthy' => true, 'message' => 'ok', 'details' => ['total_jobs' => 5, 'connection' => 'default']],
+                'storage' => ['healthy' => true, 'message' => 'ok'],
+            ],
+            'timestamp' => '2025-01-01T12:00:00+00:00',
+        ],
+    ],
+    'ReadinessResult' => [
+        ReadinessResult::class,
+        [
+            'status' => 'ready',
+            'checks' => [
+                'access_control' => ['healthy' => true, 'message' => 'ok'],
+                'api_middleware' => ['healthy' => true, 'message' => 'ok', 'details' => ['middleware' => ['auth']]],
+            ],
+            'timestamp' => '2025-01-01T12:00:00+00:00',
+        ],
+    ],
+    'AlertEntry' => [
+        AlertEntry::class,
+        ['severity' => 'warning', 'message' => '3 jobs stuck in processing', 'count' => 3],
+    ],
+    'StatisticsReport' => [
+        StatisticsReport::class,
+        [
+            'generated_at' => '2025-01-01T12:00:00+00:00',
+            'global' => ['total' => 10, 'completed' => 8],
+            'servers' => [['server_name' => 'web-1', 'total_jobs' => 5]],
+            'queue_health' => [['queue' => 'default', 'health_score' => 90.0]],
+        ],
+    ],
+    'FailedJobsReport' => [
+        FailedJobsReport::class,
+        [
+            'generated_at' => '2025-01-01T12:00:00+00:00',
+            'total_failed' => 3,
+            'by_exception' => [
+                'RuntimeException' => ['count' => 2, 'jobs' => ['uuid-1', 'uuid-2']],
+                'LogicException' => ['count' => 1, 'jobs' => ['uuid-3']],
+            ],
+            'by_queue' => ['default' => 2, 'high' => 1],
+            'recent_failures' => [
+                ['uuid' => 'uuid-1', 'job_class' => 'App\\Jobs\\Example', 'exception' => 'RuntimeException', 'failed_at' => '2025-01-01T12:00:00+00:00'],
+            ],
+        ],
+    ],
+]);
+
+test('fromArray then toArray round-trips a representative array', function (string $class, array $original) {
+    /** @var object{toArray: callable} $vo */
+    $vo = $class::fromArray($original);
+
+    expect($vo->toArray())->toBe($original);
+})->with('service value objects');
+
+test('json_encode of the value object equals json_encode of the original array', function (string $class, array $original) {
+    $vo = $class::fromArray($original);
+
+    expect(json_encode($vo))->toBe(json_encode($original));
+})->with('service value objects');
+
+test('array access returns the same values as the serialized array', function (string $class, array $original) {
+    $vo = $class::fromArray($original);
+
+    foreach ($original as $key => $value) {
+        expect($vo[$key])->toBe($value);
+        expect(isset($vo[$key]))->toBeTrue();
+    }
+})->with('service value objects');
+
+test('an unavailable WorkerData collapses to the single available key', function () {
+    expect((new WorkerData(false))->toArray())->toBe(['available' => false]);
+});
+
+test('an unavailable QueueInfraData collapses to the single available key', function () {
+    expect((new QueueInfraData(false))->toArray())->toBe(['available' => false]);
+});
+
+test('service value objects are immutable through array access', function () {
+    $entry = new AlertEntry(severity: 'warning', message: 'stuck', count: 1);
+
+    expect(fn () => $entry['severity'] = 'critical')->toThrow(LogicException::class);
+    expect(fn () => $entry['severity'])->not->toThrow(LogicException::class);
+});


### PR DESCRIPTION
The final slice of batch D — types the read methods of all four service contracts (`Infrastructure`, `Health`, `Alerting`, `Export`) with 15 `final readonly` value objects, same D1 pattern (`Arrayable` + `JsonSerializable` + `ArrayAccess`, edge-identical serialization). This completes the architecture campaign.

## Value objects (15)
`WorkerData`, `WorkerTypeBreakdown`, `QueueInfraData`, `SlaData` (+ rows promoted to `SlaQueueCompliance`), `ScalingData`, `CapacityData`, `ClusterData` (nullable), `LiveClusterState` (nullable), `ScalingTimeline`, `HealthCheckResult`, `ReadinessResult`, `AlertEntry`, `StatisticsReport`, `FailedJobsReport`.

## Serialization-boundary judgment
Stable, domain-meaningful rows were promoted to their own VOs (`SlaQueueCompliance`, `AlertEntry`). Genuinely-dynamic external telemetry — Horizon supervisor/workload blobs, raw cluster-event dumps, per-exception failure groupings keyed by runtime-discovered class names — is kept as typed `array` properties on the outer VO and documented, per the house rule's serialization-boundary exception. `CapacityData` deliberately keeps its rows as arrays to preserve the `int 0` vs `float` byte-identity a reconstructed row would risk (covered by a test).

## Edge-identity
Every existing test passes UNCHANGED — the proof that serialization is byte-for-key identical. Nullable returns stay null where they were null. Consumers converted: the dashboard/health controllers to property access at the JSON edge, the TUI and health command to `->toArray()` at their boundaries (CLI/TUI output unchanged), the `--json` health path passes VOs straight to `json_encode`.

Verified: 645 tests (579 pre-existing **unchanged** + 66 new VO tests), PHPStan level 9 clean, and the health/infrastructure/autoscale endpoints browser-verified — the health tab renders score 83 / 6 checks identically from the `HealthCheckResult` VO.

With this, the whole read path flows typed; arrays remain only at true serialization edges.