### PR TITLE
feat(security): redact secrets in exception messages and traces

### DIFF
--- a/src/Http/Controllers/DashboardDrillDownController.php
+++ b/src/Http/Controllers/DashboardDrillDownController.php
@@ -109,13 +109,16 @@ class DashboardDrillDownController extends Controller
             // Throughput (per-minute for this entity)
             $throughput = $this->statsRepository->computeThroughputByMinute(60, [$column => $value]);
 
+            /** @var array<string> $sensitiveKeys */
+            $sensitiveKeys = config('queue-monitor.api.sensitive_keys', []);
+
             // Recent jobs (last 20) with identifiable summary from payload
             $recentJobs = $this->jobsTable()
                 ->where($column, $value)
                 ->orderByDesc('queued_at')
                 ->limit(20)
                 ->get()
-                ->map(function ($job) {
+                ->map(function ($job) use ($sensitiveKeys) {
                     $summary = $this->extractJobSummary($job->payload, $job->display_name);
 
                     return [
@@ -128,7 +131,7 @@ class DashboardDrillDownController extends Controller
                         'server' => $job->server_name,
                         'duration_ms' => $job->duration_ms !== null ? (int) $job->duration_ms : null,
                         'queued_at' => $job->queued_at,
-                        'error' => $job->exception_message,
+                        'error' => PayloadRedactor::redactString($job->exception_message, $sensitiveKeys),
                     ];
                 })
                 ->values()

--- a/src/Http/Controllers/DashboardMetricsController.php
+++ b/src/Http/Controllers/DashboardMetricsController.php
@@ -53,8 +53,11 @@ class DashboardMetricsController extends Controller
         /** @var int $perPage */
         $perPage = config('queue-monitor.ui.per_page', 35);
 
+        /** @var array<string> $sensitiveKeys */
+        $sensitiveKeys = config('queue-monitor.api.sensitive_keys', []);
+
         $recentJobs = $this->jobRepository->getRecentJobs($perPage)
-            ->map(fn ($job) => JobMonitorTransformer::toListArray($job));
+            ->map(fn ($job) => JobMonitorTransformer::toListArray($job, $sensitiveKeys));
 
         $chartData = $this->statsRepository->getJobClassStatistics();
 
@@ -83,7 +86,10 @@ class DashboardMetricsController extends Controller
         $jobs = $this->jobRepository->query($filters);
         $total = $this->jobRepository->count($filters);
 
-        $data = $jobs->map(fn ($job) => JobMonitorTransformer::toListArray($job));
+        /** @var array<string> $sensitiveKeys */
+        $sensitiveKeys = config('queue-monitor.api.sensitive_keys', []);
+
+        $data = $jobs->map(fn ($job) => JobMonitorTransformer::toListArray($job, $sensitiveKeys));
 
         // Provide distinct queue names for the filter dropdown (cached to avoid full table scan)
         $availableQueues = Cache::remember($this->dashboardCache->scopedKey('available_queues'), 60, fn () => JobMonitor::query()
@@ -125,7 +131,7 @@ class DashboardMetricsController extends Controller
             : null;
 
         $retryChain = $this->jobRepository->getRetryChain($uuid)
-            ->map(fn ($retryJob) => JobMonitorTransformer::toRetryChainArray($retryJob, $uuid));
+            ->map(fn ($retryJob) => JobMonitorTransformer::toRetryChainArray($retryJob, $uuid, $sensitiveKeys));
 
         return response()->json([
             'job' => JobMonitorTransformer::toDetailArray($job, $sensitiveKeys),
@@ -133,8 +139,8 @@ class DashboardMetricsController extends Controller
             'exception' => $job->isFailed() ? [
                 'class' => $job->exception_class,
                 'short_class' => $job->getShortExceptionClass(),
-                'message' => $job->exception_message,
-                'trace' => PayloadRedactor::redactTrace($job->exception_trace),
+                'message' => PayloadRedactor::redactString($job->exception_message, $sensitiveKeys),
+                'trace' => PayloadRedactor::redactTrace($job->exception_trace, $sensitiveKeys),
             ] : null,
             'retry_chain' => $retryChain,
         ]);
@@ -176,7 +182,7 @@ class DashboardMetricsController extends Controller
 
         return response()->json([
             'payload' => PayloadRedactor::redact($job->payload, $sensitiveKeys),
-            'exception' => PayloadRedactor::redactTrace($job->exception_trace),
+            'exception' => PayloadRedactor::redactTrace($job->exception_trace, $sensitiveKeys),
         ]);
     }
 }

--- a/src/Http/Resources/JobMonitorResource.php
+++ b/src/Http/Resources/JobMonitorResource.php
@@ -60,7 +60,7 @@ class JobMonitorResource extends JsonResource
             'exception' => $this->exception_class ? [
                 'class' => $this->exception_class,
                 'short_class' => $this->getShortExceptionClass(),
-                'message' => $this->exception_message,
+                'message' => PayloadRedactor::redactString($this->exception_message, $sensitiveKeys),
             ] : null,
             'tags' => $this->tags ? PayloadRedactor::redact(
                 $this->tags,

--- a/src/Http/Transformers/JobMonitorTransformer.php
+++ b/src/Http/Transformers/JobMonitorTransformer.php
@@ -12,9 +12,10 @@ final class JobMonitorTransformer
     /**
      * Transform a job for list views (overview, jobs tab).
      *
+     * @param  array<string>  $sensitiveKeys
      * @return array<string, mixed>
      */
-    public static function toListArray(JobMonitor $job): array
+    public static function toListArray(JobMonitor $job, array $sensitiveKeys = []): array
     {
         return [
             'uuid' => $job->uuid,
@@ -43,7 +44,7 @@ final class JobMonitorTransformer
             'queued_at' => $job->queued_at->toIso8601String(),
             'started_at' => $job->started_at?->toIso8601String(),
             'completed_at' => $job->completed_at?->toIso8601String(),
-            'error' => $job->exception_message,
+            'error' => PayloadRedactor::redactString($job->exception_message, $sensitiveKeys),
             'is_failed' => $job->isFailed(),
         ];
     }
@@ -111,9 +112,10 @@ final class JobMonitorTransformer
     /**
      * Transform a job for the retry chain list.
      *
+     * @param  array<string>  $sensitiveKeys
      * @return array<string, mixed>
      */
-    public static function toRetryChainArray(JobMonitor $job, string $currentUuid): array
+    public static function toRetryChainArray(JobMonitor $job, string $currentUuid, array $sensitiveKeys = []): array
     {
         return [
             'uuid' => $job->uuid,
@@ -130,8 +132,8 @@ final class JobMonitorTransformer
             'started_at' => $job->started_at?->toIso8601String(),
             'completed_at' => $job->completed_at?->toIso8601String(),
             'exception_class' => $job->exception_class,
-            'exception_message' => $job->exception_message,
-            'exception_trace' => PayloadRedactor::redactTrace($job->exception_trace),
+            'exception_message' => PayloadRedactor::redactString($job->exception_message, $sensitiveKeys),
+            'exception_trace' => PayloadRedactor::redactTrace($job->exception_trace, $sensitiveKeys),
             'wait_time_ms' => $job->started_at !== null
                 ? (int) $job->queued_at->diffInMilliseconds($job->started_at)
                 : null,

--- a/src/Utilities/PayloadRedactor.php
+++ b/src/Utilities/PayloadRedactor.php
@@ -39,17 +39,52 @@ final class PayloadRedactor
     /**
      * Redact sensitive info from exception traces (file paths, credentials in stack frames).
      *
-     * Strips the application base path to show relative paths only.
+     * Strips the application base path to show relative paths only, and masks
+     * the value after any configured sensitive key (e.g. arguments embedded in
+     * the trace when zend.exception_ignore_args is off).
+     *
+     * @param  array<string>  $sensitiveKeys
      */
-    public static function redactTrace(?string $trace): ?string
+    public static function redactTrace(?string $trace, array $sensitiveKeys = []): ?string
     {
         if ($trace === null) {
             return null;
         }
 
         $basePath = base_path().'/';
+        $trace = str_replace($basePath, '', $trace);
 
-        return str_replace($basePath, '', $trace);
+        return self::redactString($trace, $sensitiveKeys);
+    }
+
+    /**
+     * Mask the value that follows any configured sensitive key inside a free
+     * text string (an exception message or trace) — e.g. `password=secret`,
+     * `token: sk_live_x`, or `api_key => "abc"` become `password=*****` etc.
+     * The key and separator are preserved; only the value token is masked.
+     *
+     * @param  array<string>  $sensitiveKeys
+     */
+    public static function redactString(?string $value, array $sensitiveKeys): ?string
+    {
+        if ($value === null || $value === '' || $sensitiveKeys === []) {
+            return $value;
+        }
+
+        foreach ($sensitiveKeys as $sensitiveKey) {
+            $key = preg_quote($sensitiveKey, '/');
+            $replaced = preg_replace(
+                '/('.$key.'["\']?\s*(?:=>|[=:])\s*["\']?)([^\s"\',;)&]+)/i',
+                '${1}*****',
+                $value
+            );
+
+            if ($replaced !== null) {
+                $value = $replaced;
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -90,6 +90,23 @@ test('job detail endpoint returns full job with payload and retry chain', functi
     expect($response->json('payload.password'))->toBe('*****');
 });
 
+test('job detail redacts secrets in the exception message and trace', function () {
+    config(['queue-monitor.api.sensitive_keys' => ['password', 'token']]);
+
+    $job = JobMonitor::factory()->failed()->create([
+        'exception_message' => 'SQLSTATE[HY000]: password=hunter2 rejected',
+        'exception_trace' => base_path().'/app/Jobs/Charge.php(9): auth(token=sk_live_secret)',
+    ]);
+
+    $response = getJson(route('queue-monitor.dashboard.job.detail', $job->uuid));
+
+    $response->assertOk();
+    expect($response->json('exception.message'))->not->toContain('hunter2');
+    expect($response->json('exception.message'))->toContain('password=*****');
+    expect($response->json('exception.trace'))->not->toContain('sk_live_secret');
+    expect($response->json('exception.trace'))->toContain('token=*****');
+});
+
 test('job detail returns 404 for unknown uuid', function () {
     $response = getJson(route('queue-monitor.dashboard.job.detail', 'nonexistent'));
 

--- a/tests/Unit/Utilities/PayloadRedactorTest.php
+++ b/tests/Unit/Utilities/PayloadRedactorTest.php
@@ -122,3 +122,33 @@ test('redacts sensitive array values before traversing nested payloads', functio
     expect($result['data']['commandName'])->toBe('*****');
     expect($result['data']['command'])->toBe('*****');
 });
+
+test('redactString masks the value after a sensitive key with various separators', function () {
+    $keys = ['password', 'token', 'api_key'];
+
+    expect(PayloadRedactor::redactString('SQLSTATE[HY000]: password=hunter2 failed', $keys))
+        ->toBe('SQLSTATE[HY000]: password=***** failed');
+    expect(PayloadRedactor::redactString('Auth failed with token: sk_live_abc123', $keys))
+        ->toBe('Auth failed with token: *****');
+    expect(PayloadRedactor::redactString('config api_key => "abcdef123"', $keys))
+        ->toBe('config api_key => "*****"');
+});
+
+test('redactString is case-insensitive and leaves non-sensitive text intact', function () {
+    expect(PayloadRedactor::redactString('Connection Password=secret on host db1', ['password']))
+        ->toBe('Connection Password=***** on host db1');
+    expect(PayloadRedactor::redactString('A plain error with no secrets', ['password']))
+        ->toBe('A plain error with no secrets');
+});
+
+test('redactString returns the value unchanged with no keys or null input', function () {
+    expect(PayloadRedactor::redactString('password=secret', []))->toBe('password=secret');
+    expect(PayloadRedactor::redactString(null, ['password']))->toBeNull();
+});
+
+test('redactTrace strips the base path and masks sensitive values', function () {
+    $trace = base_path().'/app/Jobs/Charge.php(42): connect(token=sk_live_xyz)';
+
+    expect(PayloadRedactor::redactTrace($trace, ['token']))
+        ->toBe('app/Jobs/Charge.php(42): connect(token=*****)');
+});


### PR DESCRIPTION
Backlog item: exception data was outside the redaction model.

Exception **messages** were served verbatim across the API resource, the dashboard job list and detail, the drill-down recent-jobs, and the retry chain — so a database error like `SQLSTATE... password=hunter2` or a message carrying `token=sk_live_...` leaked to any authorized viewer. `redactTrace()` only stripped the application base path, leaving argument values embedded in the trace when `zend.exception_ignore_args` is off.

- New `PayloadRedactor::redactString()` masks the value that follows any configured sensitive key — `password=`, `token:`, `api_key => "..."` — preserving the key, separator, and quotes, case-insensitive.
- Threaded `api.sensitive_keys` through **every** exception-serving boundary: both transformer paths (`toListArray`, `toRetryChainArray`), `JobMonitorResource`, the dashboard metrics + drill-down controllers, and the legacy payload endpoint. `redactTrace()` now applies the same masking after stripping the base path.
- **Storage stays raw** (the operator's own database); redaction happens at the serving edge, matching the existing payload-redaction model.

Real-vector tests: the separator variants for `redactString`/`redactTrace`, plus an end-to-end job-detail assertion that `hunter2` and `sk_live_secret` never reach the response. Gate: pint, PHPStan level 9, Pest 648 passed.