### PR TITLE
feat(testing): ship the InteractsWithQueueMonitor consumer trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ phpstan.neon
 phpunit.xml
 testbench.yaml
 yarn-error.log
+
+# Local agent worktrees and session data
+.claude/

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -104,6 +104,41 @@ $job = JobMonitor::factory()->create([
 ]);
 ```
 
+## Asserting monitoring in your own app
+
+Queue Monitor ships an `InteractsWithQueueMonitor` trait so your app's feature
+tests can assert what was recorded without querying the tables by hand. Use it
+in a test that migrates the package tables (for example with `RefreshDatabase`):
+
+```php
+use Cbox\LaravelQueueMonitor\Testing\InteractsWithQueueMonitor;
+
+uses(InteractsWithQueueMonitor::class);
+
+it('records the invoice job', function () {
+    dispatch(new SendInvoice($order));
+
+    $this->assertJobRecorded(SendInvoice::class);
+    $this->assertJobRecorded(SendInvoice::class, times: 1);
+    $this->assertJobRecordedWithStatus(SendInvoice::class, 'completed');
+});
+```
+
+Available assertions:
+
+| Method | Asserts |
+| --- | --- |
+| `assertJobRecorded($class, $times = null)` | the job class was recorded (optionally an exact count) |
+| `assertJobNotRecorded($class)` | the job class was never recorded |
+| `assertNothingRecorded()` | nothing was recorded at all |
+| `assertJobRecordedWithStatus($class, $status)` | a record exists with that `JobStatus` (enum or string) |
+| `assertJobCompleted($class)` | a record exists with the completed status |
+| `assertJobFailed($class)` | a record exists that failed or timed out |
+| `recordedJobs($class = null)` | the recorded `JobMonitor` models as a collection |
+
+The assertions read the real recorded state, so they work end-to-end through the
+package's own listeners and actions — no fake or stub to keep in sync.
+
 ## Writing Tests
 
 ### Unit Tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,5 +3,6 @@ parameters:
     paths:
         - src
         - database
+        - tests/Fixtures
     tmpDir: build/phpstan
     reportUnmatchedIgnoredErrors: true

--- a/src/Testing/InteractsWithQueueMonitor.php
+++ b/src/Testing/InteractsWithQueueMonitor.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Testing;
+
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Assertions for what Queue Monitor recorded, so a consuming app can verify
+ * job monitoring in its own feature tests without querying the tables by hand.
+ *
+ * Use it in a test that migrates the package tables (e.g. with RefreshDatabase);
+ * the assertions read the real recorded state.
+ *
+ * ```php
+ * use Cbox\LaravelQueueMonitor\Testing\InteractsWithQueueMonitor;
+ *
+ * uses(InteractsWithQueueMonitor::class);
+ *
+ * it('records the job', function () {
+ *     dispatch(new SendInvoice($order));
+ *     $this->assertJobRecorded(SendInvoice::class);
+ * });
+ * ```
+ */
+trait InteractsWithQueueMonitor
+{
+    /**
+     * The recorded job monitors, optionally filtered by job class.
+     *
+     * @return Collection<int, JobMonitor>
+     */
+    protected function recordedJobs(?string $jobClass = null): Collection
+    {
+        $query = JobMonitor::query();
+
+        if ($jobClass !== null) {
+            $query->where('job_class', $jobClass);
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * Assert a job of the given class was recorded, optionally an exact number
+     * of times.
+     */
+    protected function assertJobRecorded(string $jobClass, ?int $times = null): void
+    {
+        $count = $this->recordedJobs($jobClass)->count();
+
+        if ($times === null) {
+            Assert::assertGreaterThan(
+                0,
+                $count,
+                "Expected a [{$jobClass}] job to be recorded, but none was."
+            );
+
+            return;
+        }
+
+        Assert::assertSame(
+            $times,
+            $count,
+            "Expected [{$jobClass}] to be recorded {$times} time(s), but it was recorded {$count} time(s)."
+        );
+    }
+
+    /**
+     * Assert no job of the given class was recorded.
+     */
+    protected function assertJobNotRecorded(string $jobClass): void
+    {
+        $count = $this->recordedJobs($jobClass)->count();
+
+        Assert::assertSame(
+            0,
+            $count,
+            "Expected no [{$jobClass}] job to be recorded, but {$count} was."
+        );
+    }
+
+    /**
+     * Assert nothing was recorded at all.
+     */
+    protected function assertNothingRecorded(): void
+    {
+        $count = JobMonitor::query()->count();
+
+        Assert::assertSame(0, $count, "Expected no jobs to be recorded, but {$count} was.");
+    }
+
+    /**
+     * Assert a job of the given class was recorded with the given status.
+     */
+    protected function assertJobRecordedWithStatus(string $jobClass, JobStatus|string $status): void
+    {
+        $status = $status instanceof JobStatus ? $status : JobStatus::from($status);
+
+        $exists = $this->recordedJobs($jobClass)
+            ->contains(fn (JobMonitor $job): bool => $job->status === $status);
+
+        Assert::assertTrue(
+            $exists,
+            "Expected a [{$jobClass}] job recorded with status [{$status->value}], but none matched."
+        );
+    }
+
+    /**
+     * Assert a job of the given class was recorded as failed or timed out.
+     */
+    protected function assertJobFailed(string $jobClass): void
+    {
+        $exists = $this->recordedJobs($jobClass)
+            ->contains(fn (JobMonitor $job): bool => $job->isFailed());
+
+        Assert::assertTrue(
+            $exists,
+            "Expected a [{$jobClass}] job to be recorded as failed, but none was."
+        );
+    }
+
+    /**
+     * Assert a job of the given class was recorded as completed.
+     */
+    protected function assertJobCompleted(string $jobClass): void
+    {
+        $this->assertJobRecordedWithStatus($jobClass, JobStatus::COMPLETED);
+    }
+}

--- a/tests/Feature/Testing/InteractsWithQueueMonitorTest.php
+++ b/tests/Feature/Testing/InteractsWithQueueMonitorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Testing\InteractsWithQueueMonitor;
+
+uses(InteractsWithQueueMonitor::class);
+
+it('asserts a job was recorded, and how many times', function () {
+    JobMonitor::factory()->count(2)->create(['job_class' => 'App\\Jobs\\SendInvoice']);
+
+    $this->assertJobRecorded('App\\Jobs\\SendInvoice');
+    $this->assertJobRecorded('App\\Jobs\\SendInvoice', 2);
+    $this->assertJobNotRecorded('App\\Jobs\\Other');
+});
+
+it('asserts nothing was recorded on a clean slate', function () {
+    $this->assertNothingRecorded();
+});
+
+it('asserts a job was recorded with a given status', function () {
+    JobMonitor::factory()->create(['job_class' => 'App\\Jobs\\Charge', 'status' => JobStatus::COMPLETED]);
+
+    $this->assertJobRecordedWithStatus('App\\Jobs\\Charge', JobStatus::COMPLETED);
+    $this->assertJobRecordedWithStatus('App\\Jobs\\Charge', 'completed');
+    $this->assertJobCompleted('App\\Jobs\\Charge');
+});
+
+it('asserts a failed or timed-out job', function () {
+    JobMonitor::factory()->failed()->create(['job_class' => 'App\\Jobs\\Flaky']);
+
+    $this->assertJobFailed('App\\Jobs\\Flaky');
+});
+
+it('exposes the recorded jobs as a collection', function () {
+    JobMonitor::factory()->count(3)->create(['job_class' => 'App\\Jobs\\Report']);
+    JobMonitor::factory()->create(['job_class' => 'App\\Jobs\\Other']);
+
+    expect($this->recordedJobs('App\\Jobs\\Report'))->toHaveCount(3);
+    expect($this->recordedJobs())->toHaveCount(4);
+});

--- a/tests/Fixtures/UsesInteractsWithQueueMonitor.php
+++ b/tests/Fixtures/UsesInteractsWithQueueMonitor.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Tests\Fixtures;
+
+use Cbox\LaravelQueueMonitor\Testing\InteractsWithQueueMonitor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Composition site so PHPStan analyses the InteractsWithQueueMonitor trait
+ * (a trait is only analysed where it is used, and its real use is in tests,
+ * outside the analysed paths). This fixture is never executed.
+ */
+final class UsesInteractsWithQueueMonitor extends TestCase
+{
+    use InteractsWithQueueMonitor;
+}


### PR DESCRIPTION
Backlog item: no dogfooded testing surface (a house-standard gap).

A consuming app had to query the `queue_monitor` tables by hand to verify monitoring in its own tests. This ships `src/Testing/InteractsWithQueueMonitor` with assertions that read the real recorded state:

| Method | Asserts |
| --- | --- |
| `assertJobRecorded($class, $times = null)` | the job class was recorded (optionally an exact count) |
| `assertJobNotRecorded($class)` | never recorded |
| `assertNothingRecorded()` | nothing recorded at all |
| `assertJobRecordedWithStatus($class, $status)` | a record with that `JobStatus` (enum or string) |
| `assertJobCompleted($class)` / `assertJobFailed($class)` | completed / failed-or-timed-out |
| `recordedJobs($class = null)` | the recorded models as a collection |

They use PHPUnit's `Assert` (so they work in any test base) and read through the package's own listeners and actions — no fake to keep in sync. The package dogfoods it in its own suite; a `tests/Fixtures` composition site (added to the PHPStan paths) lets level 9 analyse a trait that's otherwise only used from tests. Documented in the testing reference.

Also gitignores `.claude/` (local agent worktrees) so they can't be committed by accident.

Gate: pint, PHPStan level 9, Pest 653 passed.