### PR TITLE
perf(assets): serve bundled dashboard assets from a cacheable route by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ return [
         'route_prefix' => 'queue-monitor',
         'middleware' => ['web'],
         'assets' => [
-            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'inline'),
+            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'served'),
         ],
     ],
 

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -277,11 +277,15 @@ return [
         'refresh_interval' => 3000, // ms
 
         // Dashboard asset loading strategy:
-        // - inline: load precompiled package assets directly from vendor resources/dist (default, zero setup)
+        // - served: stream the bundled assets from a package route with a long
+        //   immutable cache (default, zero setup, browser-cached across loads)
+        // - inline: embed the precompiled assets in the dashboard HTML (no extra
+        //   requests, but the ~1 MB chart library is re-sent on every load; use
+        //   for a strict CSP that forbids external scripts)
         // - public: load files from public/vendor/queue-monitor after publishing queue-monitor-assets
         // - none: emit no package assets; use a published/custom view and your own app build
         'assets' => [
-            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'inline'),
+            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'served'),
             'url' => env('QUEUE_MONITOR_ASSET_URL'), // null defaults to asset('vendor/queue-monitor')
             'paths' => [
                 'css' => 'queue-monitor.css',

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -164,7 +164,7 @@ return [
     // Web dashboard assets
     'ui' => [
         'assets' => [
-            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'inline'),
+            'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'served'),
         ],
     ],
 ];

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -176,7 +176,7 @@ Control how the built-in dashboard loads CSS and JavaScript:
 'ui' => [
     'assets' => [
         // inline, public, or none
-        'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'inline'),
+        'mode' => env('QUEUE_MONITOR_ASSET_MODE', 'served'),
         'url' => env('QUEUE_MONITOR_ASSET_URL'),
     ],
 ],

--- a/docs/guides/dashboard-assets.md
+++ b/docs/guides/dashboard-assets.md
@@ -8,19 +8,33 @@ weight: 17
 
 Queue Monitor ships with precompiled dashboard CSS and JavaScript. No Node, Vite, Livewire, or Inertia setup is required in the host application.
 
-## Default: Inline Package Assets
+## Default: Served Package Assets
 
-By default, the dashboard reads precompiled files from the installed package and inlines them into the Blade view:
+By default, the dashboard streams the precompiled files from a package route with
+a long, immutable cache, so the ~1 MB chart library is fetched once and reused
+across page loads instead of being re-sent inside every dashboard response:
+
+```env
+QUEUE_MONITOR_ASSET_MODE=served
+```
+
+This is the zero-setup mode — no publishing required — and the URLs carry a
+content-hash version, so an upgraded bundle busts the browser cache automatically.
+
+## Inline Package Assets
+
+If your Content Security Policy forbids external scripts and styles, embed the
+assets directly in the dashboard HTML instead:
 
 ```env
 QUEUE_MONITOR_ASSET_MODE=inline
 ```
 
-This is the zero-setup mode and works without publishing assets.
+This adds no extra requests, but the chart library is re-sent on every load.
 
 ## Public Static Assets
 
-If your Content Security Policy disallows inline CSS or JavaScript, publish the compiled assets:
+To serve the assets from your app's public directory (e.g. behind a CDN), publish the compiled assets:
 
 ```bash
 php artisan vendor:publish --tag="queue-monitor-assets"

--- a/routes/ui.php
+++ b/routes/ui.php
@@ -20,6 +20,9 @@ Route::prefix(config('queue-monitor.ui.route_prefix'))
         // Dashboard (tabs use #hash fragments: #jobs, #analytics, #health, #infrastructure, #autoscale)
         Route::get('/', [DashboardController::class, 'index'])->name('queue-monitor.dashboard');
 
+        // Bundled CSS/JS, streamed with a long immutable cache (served asset mode)
+        Route::get('/assets/{file}', [DashboardController::class, 'asset'])->name('queue-monitor.asset');
+
         // Deep-link views (hard-refreshable)
         Route::get('/job/{uuid}', [DashboardController::class, 'show'])->name('queue-monitor.job.view');
         Route::get('/queue/{queue}', [DashboardController::class, 'drillDownView'])->name('queue-monitor.queue.view')->where('queue', '.*');

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Cbox\LaravelQueueMonitor\Http\Controllers;
 
+use Cbox\LaravelQueueMonitor\Support\DashboardAssets;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\View\View;
 
@@ -55,6 +57,29 @@ class DashboardController extends Controller
         $value = is_string($raw) ? $raw : '';
 
         return $this->render(drillDownType: $type, drillDownValue: $value);
+    }
+
+    /**
+     * Stream a bundled dashboard asset (CSS/JS) with a long, immutable cache so
+     * the ~1 MB chart library is fetched once and reused, rather than re-inlined
+     * into every dashboard response. The file name is whitelisted against the
+     * known bundle so this cannot read arbitrary paths.
+     */
+    public function asset(string $file, DashboardAssets $assets): Response
+    {
+        $resolved = $assets->bundledAsset($file);
+
+        if ($resolved === null) {
+            abort(404);
+        }
+
+        [$contents, $contentType] = $resolved;
+
+        return response($contents, 200, [
+            'Content-Type' => $contentType,
+            'Cache-Control' => 'public, max-age=31536000, immutable',
+            'ETag' => '"'.substr(md5($contents), 0, 16).'"',
+        ]);
     }
 
     private function render(

--- a/src/Support/DashboardAssets.php
+++ b/src/Support/DashboardAssets.php
@@ -23,8 +23,9 @@ final class DashboardAssets
     {
         return match ($this->mode()) {
             'none' => new HtmlString(''),
+            'inline' => new HtmlString('<style>'.$this->inlineAsset($this->paths()['css']).'</style>'),
             'public' => new HtmlString('<link rel="stylesheet" href="'.$this->escape($this->assetUrl($this->paths()['css'])).'">'),
-            default => new HtmlString('<style>'.$this->inlineAsset($this->paths()['css']).'</style>'),
+            default => new HtmlString('<link rel="stylesheet" href="'.$this->escape($this->servedUrl('css')).'">'),
         };
     }
 
@@ -32,24 +33,77 @@ final class DashboardAssets
     {
         return match ($this->mode()) {
             'none' => new HtmlString(''),
+            'inline' => new HtmlString(
+                '<script>'.$this->inlineAsset($this->paths()['echarts']).'</script>'."\n".
+                '<script>'.$this->inlineAsset($this->paths()['alpine']).'</script>'
+            ),
             'public' => new HtmlString(
                 '<script src="'.$this->escape($this->assetUrl($this->paths()['echarts'])).'"></script>'."\n".
                 '<script src="'.$this->escape($this->assetUrl($this->paths()['alpine'])).'"></script>'
             ),
             default => new HtmlString(
-                '<script>'.$this->inlineAsset($this->paths()['echarts']).'</script>'."\n".
-                '<script>'.$this->inlineAsset($this->paths()['alpine']).'</script>'
+                '<script src="'.$this->escape($this->servedUrl('echarts')).'"></script>'."\n".
+                '<script src="'.$this->escape($this->servedUrl('alpine')).'"></script>'
             ),
         };
+    }
+
+    /**
+     * Resolve a bundle file requested through the package asset route: the
+     * contents and its content type, or null if the name is not a known bundle
+     * file (so the route can 404 without exposing arbitrary paths).
+     *
+     * @return array{0: string, 1: string}|null
+     */
+    public function bundledAsset(string $file): ?array
+    {
+        $paths = $this->paths();
+        $type = match ($file) {
+            $paths['css'] => 'text/css',
+            $paths['echarts'], $paths['alpine'] => 'text/javascript',
+            default => null,
+        };
+
+        if ($type === null) {
+            return null;
+        }
+
+        $contents = $this->inlineAsset($file);
+
+        if ($contents === '') {
+            return null;
+        }
+
+        return [$contents, $type];
     }
 
     private function mode(): string
     {
         /** @var mixed $mode */
-        $mode = config('queue-monitor.ui.assets.mode', 'inline');
-        $mode = is_string($mode) ? strtolower($mode) : 'inline';
+        $mode = config('queue-monitor.ui.assets.mode', 'served');
+        $mode = is_string($mode) ? strtolower($mode) : 'served';
 
-        return in_array($mode, ['inline', 'public', 'none'], true) ? $mode : 'inline';
+        return in_array($mode, ['served', 'inline', 'public', 'none'], true) ? $mode : 'served';
+    }
+
+    /**
+     * URL to the package asset route for a bundle key, with a content-hash
+     * version so an upgraded bundle busts the immutable browser cache.
+     */
+    private function servedUrl(string $key): string
+    {
+        $file = $this->paths()[$key];
+
+        return route('queue-monitor.asset', ['file' => $file]).'?v='.$this->assetVersion($file);
+    }
+
+    private function assetVersion(string $file): string
+    {
+        $path = $this->packageRoot().'/resources/dist/'.$file;
+
+        $hash = is_file($path) ? md5_file($path) : false;
+
+        return $hash !== false ? substr($hash, 0, 8) : 'dev';
     }
 
     /**

--- a/tests/Feature/Actions/PruneJobsActionTest.php
+++ b/tests/Feature/Actions/PruneJobsActionTest.php
@@ -60,8 +60,11 @@ test('prune action enforces max_rows limit', function () {
         'status' => JobStatus::COMPLETED,
     ]);
 
+    // A large day window so time-based pruning never touches these just-created
+    // rows — this test isolates the max_rows cap, so the count must not depend
+    // on how much wall-clock elapsed before the prune ran.
     $action = app(PruneJobsAction::class);
-    $deleted = $action->execute(days: 0, maxRows: 5);
+    $deleted = $action->execute(days: 365, maxRows: 5);
 
     expect($deleted)->toBe(5);
     expect(JobMonitor::count())->toBe(5);

--- a/tests/Feature/Controllers/DashboardWebTest.php
+++ b/tests/Feature/Controllers/DashboardWebTest.php
@@ -32,6 +32,35 @@ test('dashboard renders package-local assets without external CDN dependencies',
         ->toContain('echarts');
 });
 
+test('dashboard serves bundled assets from the package route by default', function () {
+    View::addNamespace('queue-monitor-source', dirname(__DIR__, 3).'/resources/views');
+
+    $html = view('queue-monitor-source::web.dashboard')->render();
+
+    // Default 'served' mode: external tags at the package asset route with a
+    // content-hash version, not the ~1 MB chart library inlined per response.
+    expect($html)
+        ->toContain('/queue-monitor/assets/echarts.min.js?v=')
+        ->toContain('/queue-monitor/assets/alpine.min.js?v=')
+        ->toContain('/queue-monitor/assets/queue-monitor.css?v=')
+        ->not->toContain('<style>@charset');
+});
+
+test('the asset route streams a bundled file with an immutable cache and 404s unknown files', function () {
+    $response = get('/queue-monitor/assets/alpine.min.js');
+
+    $response->assertOk();
+    $cacheControl = (string) $response->headers->get('Cache-Control');
+    expect($cacheControl)->toContain('max-age=31536000')
+        ->and($cacheControl)->toContain('public')
+        ->and($cacheControl)->toContain('immutable');
+    expect($response->headers->get('Content-Type'))->toContain('javascript');
+    expect($response->headers->get('ETag'))->not->toBeNull();
+
+    get('/queue-monitor/assets/secrets.env')->assertNotFound();
+    get('/queue-monitor/assets/queue-monitor.css')->assertOk();
+});
+
 test('dashboard can render published public asset tags', function () {
     config()->set('queue-monitor.ui.assets.mode', 'public');
     config()->set('queue-monitor.ui.assets.url', '/assets/queue-monitor');


### PR DESCRIPTION
Final backlog item: the ~1 MB inline chart bundle.

The default `inline` asset mode embedded ECharts (~1 MB) into **every** dashboard response — uncacheable, re-sent on each load and deep-link reload. The new default **`served`** mode streams the CSS/JS from a package route (`GET {prefix}/assets/{file}`) with `Cache-Control: public, max-age=31536000, immutable` and a content-hash `?v=` version, so the browser fetches each file once and reuses it across loads; an upgraded bundle busts the cache automatically. The requested file name is whitelisted against the known bundle, so the route can't read arbitrary paths.

- Loading stays **synchronous and in order** (identical to the existing `public` mode), so `echarts` and `Alpine` are defined before the dashboard boots — no chart-init changes were needed.
- `inline` remains an explicit opt-in for a strict CSP that forbids external scripts; `public` and `none` are unchanged.
- External same-origin scripts are also friendlier to CSP (`script-src 'self'`) than the old `unsafe-inline`.

Tests: the served-mode tags, the route's cache headers + content type, the whitelist 404, and all four modes. The dashboard boot and a chart render were verified in a browser. Docs updated to the new default. Gate: pint, PHPStan level 9, Pest 655 passed, assets rebuilt clean.

**This completes the post-release backlog** (E1 phpstan baseline, E2 dead action, E3 exception redaction, E4 testing traits, E5 asset weight, E6 a11y).