### PR TITLE
fix(cache): survive a deploy — never return a value object cached by a prior release

### DIFF
--- a/src/Repositories/Eloquent/EloquentStatisticsRepository.php
+++ b/src/Repositories/Eloquent/EloquentStatisticsRepository.php
@@ -17,6 +17,7 @@ use Cbox\LaravelQueueMonitor\DataTransferObjects\ThroughputBucket;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
 use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
+use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
 use Cbox\LaravelQueueMonitor\Utilities\DatabaseExpressionHelper;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Database\Query\Builder;
@@ -611,7 +612,7 @@ final readonly class EloquentStatisticsRepository implements StatisticsRepositor
 
         // Return cached value if available
         $cached = $cache->get($fullKey);
-        if ($cached !== null) {
+        if ($cached !== null && ! DashboardCacheService::isStaleCache($cached)) {
             return $cached;
         }
 
@@ -623,7 +624,7 @@ final readonly class EloquentStatisticsRepository implements StatisticsRepositor
             return $cache->lock($lockKey, 15)->block(30, function () use ($cache, $fullKey, $effectiveTtl, $callback) {
                 // Double-check after acquiring lock (another process may have filled it)
                 $cached = $cache->get($fullKey);
-                if ($cached !== null) {
+                if ($cached !== null && ! DashboardCacheService::isStaleCache($cached)) {
                     return $cached;
                 }
 

--- a/src/Services/DashboardCacheService.php
+++ b/src/Services/DashboardCacheService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cbox\LaravelQueueMonitor\Services;
 
 use Cbox\LaravelQueueMonitor\Services\Contracts\DashboardCacheServiceContract;
+use Composer\InstalledVersions;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 
@@ -64,7 +65,10 @@ final class DashboardCacheService implements DashboardCacheServiceContract
         $fullKey = $this->scopedKey($key);
         $cached = $cache->get($fullKey);
 
-        if ($cached !== null) {
+        // A value serialized by a previous release can come back as an
+        // __PHP_Incomplete_Class (or hold one) when its class no longer matches;
+        // treat that as a miss and recompute rather than returning a broken value.
+        if ($cached !== null && ! self::isStaleCache($cached)) {
             return $cached;
         }
 
@@ -72,6 +76,27 @@ final class DashboardCacheService implements DashboardCacheServiceContract
         $cache->put($fullKey, $value, $ttl ?? $cacheTtl);
 
         return $value;
+    }
+
+    /**
+     * Whether a cached value is (or shallowly contains) an incomplete class —
+     * the signature of a value serialized by an incompatible earlier release.
+     */
+    public static function isStaleCache(mixed $value): bool
+    {
+        if ($value instanceof \__PHP_Incomplete_Class) {
+            return true;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                if ($item instanceof \__PHP_Incomplete_Class) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function version(): int
@@ -96,7 +121,28 @@ final class DashboardCacheService implements DashboardCacheServiceContract
         /** @var string $prefix */
         $prefix = config('queue-monitor.cache.prefix', 'queue_monitor_');
 
-        return $prefix;
+        // Namespace the cache by the installed package release. Cached values
+        // now include typed value objects, which serialize as objects; a
+        // persistent cache (redis/database) outlives a deploy, and a value
+        // object serialized by a previous release unserializes to
+        // __PHP_Incomplete_Class and fails the new strict return types. Keying
+        // by the release orphans every pre-deploy entry so nothing stale is
+        // ever read back.
+        return $prefix.'r'.self::releaseFingerprint().':';
+    }
+
+    private static function releaseFingerprint(): string
+    {
+        if (class_exists(InstalledVersions::class)) {
+            $reference = InstalledVersions::getReference('cboxdk/laravel-queue-monitor')
+                ?? InstalledVersions::getVersion('cboxdk/laravel-queue-monitor');
+
+            if (is_string($reference) && $reference !== '') {
+                return substr(hash('xxh128', $reference), 0, 12);
+            }
+        }
+
+        return 'dev';
     }
 
     private function cacheStore(): Repository

--- a/src/Services/HealthCheckService.php
+++ b/src/Services/HealthCheckService.php
@@ -26,9 +26,11 @@ final class HealthCheckService implements HealthCheckServiceContract
         $cachePrefix = config('queue-monitor.cache.prefix', 'queue_monitor_');
 
         if (config('queue-monitor.cache.enabled', true)) {
-            /** @var HealthCheckResult|null $cached */
             $cached = Cache::get($cachePrefix.'health_check');
-            if ($cached !== null) {
+            // A HealthCheckResult serialized by a previous release comes back as
+            // an __PHP_Incomplete_Class after a deploy; treat it as a miss and
+            // recompute rather than returning it into the strict return type.
+            if ($cached instanceof HealthCheckResult) {
                 return $cached;
             }
         }

--- a/tests/Feature/Services/CacheIncompleteClassTest.php
+++ b/tests/Feature/Services/CacheIncompleteClassTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\DataTransferObjects\GlobalStatistics;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Repositories\Contracts\StatisticsRepositoryContract;
+use Cbox\LaravelQueueMonitor\Services\DashboardCacheService;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    config()->set('queue-monitor.cache.enabled', true);
+});
+
+it('detects an incomplete class, top-level and nested', function () {
+    $incomplete = unserialize('O:24:"Some\\Removed\\CachedClass":0:{}');
+
+    expect(DashboardCacheService::isStaleCache($incomplete))->toBeTrue();
+    expect(DashboardCacheService::isStaleCache([$incomplete]))->toBeTrue();
+    expect(DashboardCacheService::isStaleCache(['total' => 1]))->toBeFalse();
+    expect(DashboardCacheService::isStaleCache(new GlobalStatistics(total: 1)))->toBeFalse();
+});
+
+it('recomputes global statistics when the cache holds a value from an incompatible release', function () {
+    JobMonitor::factory()->count(3)->create();
+
+    $repo = app(StatisticsRepositoryContract::class);
+    $cache = app(DashboardCacheService::class);
+
+    // A value serialized by a class that no longer exists, exactly as a
+    // pre-deploy cached value object comes back after a deploy.
+    $stale = unserialize('O:24:"Some\\Removed\\CachedClass":0:{}');
+    Cache::put($cache->scopedKey('global_statistics'), $stale, 300);
+
+    // Must not return the incomplete class into the strict return type.
+    $result = $repo->getGlobalStatistics();
+
+    expect($result)->toBeInstanceOf(GlobalStatistics::class);
+    expect($result->total)->toBe(3);
+});
+
+it('namespaces the cache key by release so a deploy orphans stale entries', function () {
+    $key = app(DashboardCacheService::class)->scopedKey('global_statistics');
+
+    // r<fingerprint> segment isolates one release's cache from another's.
+    expect($key)->toMatch('/queue_monitor_r[0-9a-f]+:v\d+:global_statistics/');
+});


### PR DESCRIPTION
**Production hotfix** for the 500s on `metrics`/`health` after upgrading to v1.10.0.

## Root cause
The typed read models (v1.10.0) made `remember()` cache **value objects**, which serialize as objects. A persistent cache (redis/database) outlives a deploy, so a `GlobalStatistics` (or any cached VO) serialized by the *previous* release unserializes to `__PHP_Incomplete_Class` in the new one — which fails the strict `: GlobalStatistics` return type with a `TypeError`, 500ing every metrics/health poll. `php artisan cache:clear` only helps if it targets the store the dashboard actually uses (`QUEUE_MONITOR_CACHE_STORE`).

## Fix (two layers, both deploy- and store-agnostic)
1. **Release-namespaced cache** — the cache key now includes the installed package release (Composer reference), so deploying this patch orphans every pre-deploy entry; nothing stale is ever read back. This is the clean sweep that fixes prod on deploy even if `cache:clear` missed the store.
2. **Incomplete-class guard** — every cache read (the statistics `remember` incl. its stampede-lock double-check, the dashboard cache, and the health check) treats an `__PHP_Incomplete_Class` as a miss and recomputes, so it self-heals regardless of store or deploy timing.

Tested with a genuine incomplete-class value planted in the cache: `getGlobalStatistics()` now recomputes to a real VO instead of throwing. Gate: pint, PHPStan level 9, Pest 658 passed.

Ships as **v1.10.1**. Deploying it (composer update + the release-namespaced keys) resolves the incident.