### PR TITLE
[Feature] queue-monitor:resolve-stuck command + null-safe update()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
+## Unreleased
+
+### Fixes
+
+- **`update()` no longer throws a `TypeError` when the row is deleted mid-update.** `EloquentJobMonitorRepository::update()` ended with `return $job->fresh();` behind a non-nullable `JobMonitor` return type. `Model::fresh()` re-reads the row and returns `null` when it no longer exists, so on a busy queue where a row is pruned (scheduled prune or the `max_rows` retention sweep) in the window between the `UPDATE` and the re-read, the method returned `null` through its non-nullable signature and threw `TypeError: ...update(): Return value must be of type ...\JobMonitor, null returned`. Every writer that records job state (started / completed / failed / timeout, cancel, resolve-stuck) was exposed. `update()` now falls back to the already-updated in-memory model (`$job->fresh() ?? $job`); the persisted change is unchanged and callers always receive a valid `JobMonitor`.
+
 ## v1.10.2 — Overview declutter - 2026-08-27
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `laravel-queue-monitor` will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- **`queue-monitor:resolve-stuck` command to clear stuck `processing` rows.** A worker killed mid-job (scale-in, OOM, SIGKILL) leaves its row in `processing` forever — no `JobProcessed`/`JobFailed` fires — and the default terminal prune statuses never reclaim it, so those rows accumulate and consume the `max_rows` budget. The package already detected stuck jobs (`QueryBuilderHelper::stuck()`, the health/alert checks) and could resolve them, but only through the REST API. This adds a schedulable command that marks jobs stuck in `processing` past a threshold as `timeout` (terminal, no replay), so the normal terminal-scoped prune reclaims them and the stuck-jobs health check clears. It is **opt-in**: the new `retention.resolve_stuck_after_minutes` config (env `QUEUE_MONITOR_RESOLVE_STUCK_AFTER_MINUTES`) defaults to `null` (disabled), and the command no-ops until configured or given `--minutes`. Supports `--dry-run`. Detection is start-age based with no heartbeat, so the threshold should sit above the longest legitimate job. `ResolveStuckJobAction` gains a `timeout` action (mark terminal without replay) backing the command.
+
 ### Fixes
 
 - **`update()` no longer throws a `TypeError` when the row is deleted mid-update.** `EloquentJobMonitorRepository::update()` ended with `return $job->fresh();` behind a non-nullable `JobMonitor` return type. `Model::fresh()` re-reads the row and returns `null` when it no longer exists, so on a busy queue where a row is pruned (scheduled prune or the `max_rows` retention sweep) in the window between the `UPDATE` and the re-read, the method returned `null` through its non-nullable signature and threw `TypeError: ...update(): Return value must be of type ...\JobMonitor, null returned`. Every writer that records job state (started / completed / failed / timeout, cancel, resolve-stuck) was exposed. `update()` now falls back to the already-updated in-memory model (`$job->fresh() ?? $job`); the persisted change is unchanged and callers always receive a valid `JobMonitor`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
-## Unreleased
-
-### Added
-
-- **`queue-monitor:resolve-stuck` command to clear stuck `processing` rows.** A worker killed mid-job (scale-in, OOM, SIGKILL) leaves its row in `processing` forever — no `JobProcessed`/`JobFailed` fires — and the default terminal prune statuses never reclaim it, so those rows accumulate and consume the `max_rows` budget. The package already detected stuck jobs (`QueryBuilderHelper::stuck()`, the health/alert checks) and could resolve them, but only through the REST API. This adds a schedulable command that marks jobs stuck in `processing` past a threshold as `timeout` (terminal, no replay), so the normal terminal-scoped prune reclaims them and the stuck-jobs health check clears. It is **opt-in**: the new `retention.resolve_stuck_after_minutes` config (env `QUEUE_MONITOR_RESOLVE_STUCK_AFTER_MINUTES`) defaults to `null` (disabled), and the command no-ops until configured or given `--minutes`. Supports `--dry-run`. Detection is start-age based with no heartbeat, so the threshold should sit above the longest legitimate job. `ResolveStuckJobAction` gains a `timeout` action (mark terminal without replay) backing the command.
-
-### Fixes
-
-- **`update()` no longer throws a `TypeError` when the row is deleted mid-update.** `EloquentJobMonitorRepository::update()` ended with `return $job->fresh();` behind a non-nullable `JobMonitor` return type. `Model::fresh()` re-reads the row and returns `null` when it no longer exists, so on a busy queue where a row is pruned (scheduled prune or the `max_rows` retention sweep) in the window between the `UPDATE` and the re-read, the method returned `null` through its non-nullable signature and threw `TypeError: ...update(): Return value must be of type ...\JobMonitor, null returned`. Every writer that records job state (started / completed / failed / timeout, cancel, resolve-stuck) was exposed. `update()` now falls back to the already-updated in-memory model (`$job->fresh() ?? $job`); the persisted change is unchanged and callers always receive a valid `JobMonitor`.
-
 ## v1.10.2 — Overview declutter - 2026-08-27
 
 ### Fixes

--- a/config/queue-monitor.php
+++ b/config/queue-monitor.php
@@ -116,6 +116,13 @@ return [
         // Failed and timeout jobs are included to prevent unbounded growth
         'prune_statuses' => ['completed', 'failed', 'timeout'],
 
+        // Minutes after which a job still in `processing` is treated as stuck and
+        // marked `timeout` by the queue-monitor:resolve-stuck command. Null disables
+        // automatic resolution (the default). Detection is start-age based with no
+        // heartbeat, so set this comfortably above your longest legitimate job so a
+        // slow-but-live job is never timed out.
+        'resolve_stuck_after_minutes' => env('QUEUE_MONITOR_RESOLVE_STUCK_AFTER_MINUTES'),
+
         // Days to retain full JSON payloads in cluster_events.meta.
         // After this period, meta is nulled but typed columns preserved for trends.
         // Set to null to disable payload pruning (keep payloads for full retention period).

--- a/src/Actions/ResolveStuckJobAction.php
+++ b/src/Actions/ResolveStuckJobAction.php
@@ -65,6 +65,21 @@ final readonly class ResolveStuckJobAction
                 } catch (\RuntimeException $e) {
                     $errors[] = "Job {$uuid} marked as timeout but replay failed: {$e->getMessage()}";
                 }
+            } elseif ($action === 'timeout') {
+                // Mark the stuck attempt terminal without replaying it, so a
+                // count/age prune can reclaim the row and the stuck-jobs health
+                // check clears. Used by the queue-monitor:resolve-stuck command.
+                $completedAt = now();
+                $durationMs = $job->started_at !== null
+                    ? max(0, (int) $job->started_at->diffInMilliseconds($completedAt))
+                    : null;
+
+                $this->repository->update($uuid, [
+                    'status' => JobStatus::TIMEOUT,
+                    'completed_at' => $completedAt,
+                    'duration_ms' => $durationMs,
+                ]);
+                $resolved++;
             }
         }
 

--- a/src/Commands/ResolveStuckJobsCommand.php
+++ b/src/Commands/ResolveStuckJobsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cbox\LaravelQueueMonitor\Commands;
+
+use Cbox\LaravelQueueMonitor\Actions\ResolveStuckJobAction;
+use Cbox\LaravelQueueMonitor\Utilities\QueryBuilderHelper;
+use Illuminate\Console\Command;
+
+class ResolveStuckJobsCommand extends Command
+{
+    public $signature = 'queue-monitor:resolve-stuck
+                        {--minutes= : Minutes after which a processing job is considered stuck (defaults to retention.resolve_stuck_after_minutes)}
+                        {--dry-run : List the jobs that would be resolved without changing them}';
+
+    public $description = 'Mark jobs stuck in processing as timed out';
+
+    public function handle(ResolveStuckJobAction $action): int
+    {
+        if (! config('queue-monitor.enabled', true)) {
+            $this->info('Queue monitoring is disabled; nothing to resolve.');
+
+            return self::SUCCESS;
+        }
+
+        $minutes = $this->resolveThresholdMinutes();
+
+        if ($minutes === null) {
+            $this->info('No stuck-job threshold configured (retention.resolve_stuck_after_minutes); skipping.');
+
+            return self::SUCCESS;
+        }
+
+        /** @var list<string> $uuids */
+        $uuids = QueryBuilderHelper::stuck($minutes)->pluck('uuid')->all();
+
+        if ($uuids === []) {
+            $this->info('No stuck jobs found.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info(count($uuids)." stuck job(s) older than {$minutes} minute(s) would be marked as timed out.");
+
+            return self::SUCCESS;
+        }
+
+        $result = $action->execute($uuids, 'timeout');
+
+        $this->info("Marked {$result['resolved']} stuck job(s) as timed out.");
+
+        foreach ($result['errors'] as $error) {
+            $this->warn($error);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function resolveThresholdMinutes(): ?int
+    {
+        $option = $this->option('minutes');
+
+        if (is_numeric($option)) {
+            return max(0, (int) $option);
+        }
+
+        $configured = config('queue-monitor.retention.resolve_stuck_after_minutes');
+
+        return is_numeric($configured) ? max(0, (int) $configured) : null;
+    }
+}

--- a/src/LaravelQueueMonitorServiceProvider.php
+++ b/src/LaravelQueueMonitorServiceProvider.php
@@ -9,6 +9,7 @@ use Cbox\LaravelQueueMonitor\Commands\LaravelQueueMonitorCommand;
 use Cbox\LaravelQueueMonitor\Commands\PruneJobsCommand;
 use Cbox\LaravelQueueMonitor\Commands\QueueMonitorDashboardCommand;
 use Cbox\LaravelQueueMonitor\Commands\ReplayJobCommand;
+use Cbox\LaravelQueueMonitor\Commands\ResolveStuckJobsCommand;
 use Cbox\LaravelQueueMonitor\Listeners\JobDebouncedListener;
 use Cbox\LaravelQueueMonitor\Listeners\JobExceptionOccurredListener;
 use Cbox\LaravelQueueMonitor\Listeners\JobFailedListener;
@@ -43,6 +44,7 @@ class LaravelQueueMonitorServiceProvider extends PackageServiceProvider
                 LaravelQueueMonitorCommand::class,
                 PruneJobsCommand::class,
                 ReplayJobCommand::class,
+                ResolveStuckJobsCommand::class,
                 HealthCheckCommand::class,
                 QueueMonitorDashboardCommand::class,
             ]);

--- a/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
+++ b/src/Repositories/Eloquent/EloquentJobMonitorRepository.php
@@ -68,8 +68,11 @@ final class EloquentJobMonitorRepository implements JobMonitorRepositoryContract
         $job->update($data);
         $this->invalidateDashboardCaches();
 
-        /** @var JobMonitor */
-        return $job->fresh();
+        // fresh() re-reads the row and returns null when it has been deleted
+        // (e.g. pruned concurrently) between the update and the re-read. The
+        // in-memory model already reflects $data, so fall back to it rather than
+        // returning null through the non-nullable signature.
+        return $job->fresh() ?? $job;
     }
 
     public function findByUuid(string $uuid): ?JobMonitor

--- a/tests/Feature/Commands/ResolveStuckCommandTest.php
+++ b/tests/Feature/Commands/ResolveStuckCommandTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\Enums\JobStatus;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+
+test('resolve-stuck marks old processing jobs as timed out', function () {
+    config()->set('queue-monitor.retention.resolve_stuck_after_minutes', 30);
+
+    $stuck = JobMonitor::factory()->create([
+        'status' => JobStatus::PROCESSING,
+        'started_at' => now()->subMinutes(45),
+        'completed_at' => null,
+    ]);
+
+    $this->artisan('queue-monitor:resolve-stuck')
+        ->expectsOutputToContain('Marked 1 stuck job(s) as timed out.')
+        ->assertSuccessful();
+
+    $stuck->refresh();
+
+    expect($stuck->status)->toBe(JobStatus::TIMEOUT)
+        ->and($stuck->completed_at)->not->toBeNull();
+});
+
+test('resolve-stuck leaves processing jobs within the threshold untouched', function () {
+    config()->set('queue-monitor.retention.resolve_stuck_after_minutes', 30);
+
+    $live = JobMonitor::factory()->create([
+        'status' => JobStatus::PROCESSING,
+        'started_at' => now()->subMinutes(5),
+        'completed_at' => null,
+    ]);
+
+    $this->artisan('queue-monitor:resolve-stuck')
+        ->expectsOutputToContain('No stuck jobs found.')
+        ->assertSuccessful();
+
+    expect($live->fresh()->status)->toBe(JobStatus::PROCESSING);
+});
+
+test('resolve-stuck skips when no threshold is configured', function () {
+    config()->set('queue-monitor.retention.resolve_stuck_after_minutes', null);
+
+    $stuck = JobMonitor::factory()->create([
+        'status' => JobStatus::PROCESSING,
+        'started_at' => now()->subMinutes(120),
+        'completed_at' => null,
+    ]);
+
+    $this->artisan('queue-monitor:resolve-stuck')
+        ->expectsOutputToContain('No stuck-job threshold configured')
+        ->assertSuccessful();
+
+    expect($stuck->fresh()->status)->toBe(JobStatus::PROCESSING);
+});
+
+test('resolve-stuck honors the --minutes option over config', function () {
+    config()->set('queue-monitor.retention.resolve_stuck_after_minutes', null);
+
+    $stuck = JobMonitor::factory()->create([
+        'status' => JobStatus::PROCESSING,
+        'started_at' => now()->subMinutes(20),
+        'completed_at' => null,
+    ]);
+
+    $this->artisan('queue-monitor:resolve-stuck', ['--minutes' => 10])
+        ->expectsOutputToContain('Marked 1 stuck job(s) as timed out.')
+        ->assertSuccessful();
+
+    expect($stuck->fresh()->status)->toBe(JobStatus::TIMEOUT);
+});
+
+test('resolve-stuck --dry-run reports without changing rows', function () {
+    config()->set('queue-monitor.retention.resolve_stuck_after_minutes', 30);
+
+    $stuck = JobMonitor::factory()->create([
+        'status' => JobStatus::PROCESSING,
+        'started_at' => now()->subMinutes(45),
+        'completed_at' => null,
+    ]);
+
+    $this->artisan('queue-monitor:resolve-stuck', ['--dry-run' => true])
+        ->expectsOutputToContain('would be marked as timed out')
+        ->assertSuccessful();
+
+    expect($stuck->fresh()->status)->toBe(JobStatus::PROCESSING);
+});

--- a/tests/Feature/Repositories/JobMonitorRepositoryTest.php
+++ b/tests/Feature/Repositories/JobMonitorRepositoryTest.php
@@ -6,6 +6,7 @@ use Cbox\LaravelQueueMonitor\DataTransferObjects\JobFilterData;
 use Cbox\LaravelQueueMonitor\Enums\JobStatus;
 use Cbox\LaravelQueueMonitor\Models\JobMonitor;
 use Cbox\LaravelQueueMonitor\Repositories\Contracts\JobMonitorRepositoryContract;
+use Illuminate\Support\Facades\DB;
 
 beforeEach(function () {
     $this->repository = app(JobMonitorRepositoryContract::class);
@@ -81,3 +82,40 @@ test('prune removes old jobs', function () {
     expect($deleted)->toBe(1);
     expect(JobMonitor::count())->toBe(1);
 });
+
+test('update persists changes and returns the refreshed record', function () {
+    $job = JobMonitor::factory()->create(['status' => JobStatus::PROCESSING]);
+
+    $updated = $this->repository->update($job->uuid, [
+        'status' => JobStatus::COMPLETED,
+    ]);
+
+    expect($updated)->toBeInstanceOf(JobMonitor::class);
+    expect($updated->uuid)->toBe($job->uuid);
+    expect($updated->status)->toBe(JobStatus::COMPLETED);
+    expect(JobMonitor::firstWhere('uuid', $job->uuid)->status)->toBe(JobStatus::COMPLETED);
+});
+
+test('update returns the in-memory record when the row is deleted mid-update', function () {
+    $job = JobMonitor::factory()->create(['status' => JobStatus::PROCESSING]);
+
+    // Simulate a concurrent prune deleting the row in the window between the
+    // UPDATE and the fresh() re-read, which makes fresh() return null.
+    JobMonitor::updated(function (JobMonitor $updated) use ($job): void {
+        if ($updated->getKey() === $job->getKey()) {
+            DB::table($job->getTable())->where('id', $job->getKey())->delete();
+        }
+    });
+
+    $updated = $this->repository->update($job->uuid, [
+        'status' => JobStatus::COMPLETED,
+    ]);
+
+    expect($updated)->toBeInstanceOf(JobMonitor::class);
+    expect($updated->status)->toBe(JobStatus::COMPLETED);
+    expect(JobMonitor::firstWhere('uuid', $job->uuid))->toBeNull();
+});
+
+test('update throws when the uuid does not exist', function () {
+    $this->repository->update('missing-uuid', ['status' => JobStatus::COMPLETED]);
+})->throws(RuntimeException::class);


### PR DESCRIPTION
> Bundles a small bug fix and a related feature — happy to split into two PRs if you'd prefer.

## What

Two related changes to how in-flight / stuck job rows are handled:

1. **`EloquentJobMonitorRepository::update()` never returns `null` through its non-nullable signature.** It ended with `return $job->fresh();`. `Model::fresh()` returns `null` when the row has been deleted between the `UPDATE` and the re-read (a concurrent prune / `max_rows` sweep, a dashboard delete, or `resolve-stuck --delete`). On a busy queue this threw `TypeError: ...update(): Return value must be of type ...\JobMonitor, null returned` from every state writer (started / completed / failed / timeout, cancel, resolve-stuck). It now falls back to the already-updated in-memory model.

2. **New `queue-monitor:resolve-stuck` command** to clear rows stranded in `processing`.

## Why

A worker killed mid-job (scale-in, OOM, SIGKILL) leaves its row in `processing` forever — no `JobProcessed`/`JobFailed` fires — and the default terminal `prune_statuses` never reclaim it, so stuck rows accumulate and consume the `max_rows` budget. The package already *detects* stuck jobs (`QueryBuilderHelper::stuck()`, the health + alert checks) and can resolve them, but only through the REST API (`StuckJobController`) — there is no CLI or schedulable path. Consumers are therefore forced to prune `processing` by age themselves; because `PruneJobsAction` feeds one status list into both the age prune and the row-count `max_rows` sweep, that also exposes in-flight rows to the count sweep, which can delete a row mid-completion and trigger exactly the `fresh()`-null `TypeError` above.

## How

- `EloquentJobMonitorRepository::update()`: `return $job->fresh() ?? $job;` (and drop the misleading inline `@var`). The persisted change is identical; callers always receive a valid `JobMonitor`.
- `queue-monitor:resolve-stuck`: finds jobs stuck in `processing` past a threshold via `QueryBuilderHelper::stuck()` and marks them `timeout` (terminal), so the normal terminal prune reclaims them and the stuck-jobs health check clears.
  - **Opt-in**: new `retention.resolve_stuck_after_minutes` config (env `QUEUE_MONITOR_RESOLVE_STUCK_AFTER_MINUTES`), `null` / disabled by default; the command no-ops until configured or given `--minutes`.
  - `--dry-run` to preview.
  - Marks terminal **without replaying** — `ResolveStuckJobAction` gains a `timeout` action, distinct from the existing `retry` (which replays) and `delete`.
  - Detection is start-age based (no heartbeat), so the config comment tells operators to set the threshold above their longest legitimate job.
- Registered the command in the service provider; `CHANGELOG.md` updated.

## Testing

- New feature tests for `queue-monitor:resolve-stuck`: marks stuck rows, respects the threshold, `--minutes` override, `--dry-run`, and the disabled-by-default no-op.
- New repository tests for the `update()` fallback: normal path, plus row-pruned-mid-update returns the in-memory model without throwing.
- `composer analyse` (PHPStan) and `pint` clean.

## Checklist

- [x] Code formatted with Pint
- [x] PHPStan passes
- [x] Tests added
- [ ] Documentation updated (happy to add a docs page for the command if you'd like)
