### PR TITLE
[Fix] Don't record a released job as completed or flip it to failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
-## v1.10.2 — Overview declutter - 2026-08-27
+## Unreleased
+
+### Fixes
+
+- **A released job is no longer recorded as `completed`.** Laravel fires `JobProcessed` after a job's `fire()` regardless of whether the job released itself back onto the queue (rate limiting, middleware, a manual `release()`), so `RecordJobCompletedAction` marked the still-in-flight attempt `completed`. On the next delivery `RecordJobStartedAction` (seeing `attempts() > 1` on a non-finished prior row) then created a fresh attempt row, so a job released N times produced N+1 rows with the first N wrongly counted as completions. `RecordJobCompletedAction` now returns early when `$event->job->isReleased()`, and `RecordJobStartedAction` distinguishes a genuine retry (the prior attempt recorded an exception, or is already finished) from a plain release (still `processing`, no exception): a real retry keeps the per-attempt trail, while a release updates the same row in place — no phantom completion, no spurious failure, and no row-per-release growth.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
-## Unreleased
-
-### Fixes
-
-- **A released job is no longer recorded as `completed`.** Laravel fires `JobProcessed` after a job's `fire()` regardless of whether the job released itself back onto the queue (rate limiting, middleware, a manual `release()`), so `RecordJobCompletedAction` marked the still-in-flight attempt `completed`. On the next delivery `RecordJobStartedAction` (seeing `attempts() > 1` on a non-finished prior row) then created a fresh attempt row, so a job released N times produced N+1 rows with the first N wrongly counted as completions. `RecordJobCompletedAction` now returns early when `$event->job->isReleased()`, and `RecordJobStartedAction` distinguishes a genuine retry (the prior attempt recorded an exception, or is already finished) from a plain release (still `processing`, no exception): a real retry keeps the per-attempt trail, while a release updates the same row in place — no phantom completion, no spurious failure, and no row-per-release growth.
+## v1.10.2 — Overview declutter - 2026-08-27
 
 ### Fixes
 

--- a/src/Actions/Core/RecordJobCompletedAction.php
+++ b/src/Actions/Core/RecordJobCompletedAction.php
@@ -30,6 +30,15 @@ final readonly class RecordJobCompletedAction
             return;
         }
 
+        // A released job (rate limiting, middleware, or a manual release) still
+        // fires JobProcessed, but the attempt did not complete — it will run
+        // again. Recording it as `completed` inflates completion counts and, with
+        // the redelivery, leaves a row per release. Leave the attempt row for the
+        // redelivery to update in place.
+        if ($job->isReleased()) {
+            return;
+        }
+
         $jobId = $job->getJobId();
         $jobMonitor = $this->repository->findLatestAttemptByJobId($jobId);
 

--- a/src/Actions/Core/RecordJobStartedAction.php
+++ b/src/Actions/Core/RecordJobStartedAction.php
@@ -57,7 +57,30 @@ final readonly class RecordJobStartedAction
             $workerContext = $this->workerContext->capture();
 
             if ($attempt > 1) {
-                // Mark the previous attempt as FAILED (Laravel doesn't fire JobFailed for intermediate retries)
+                $priorAttemptFailed = $jobMonitor->status->isFinished()
+                    || $jobMonitor->exception_class !== null;
+
+                if (! $priorAttemptFailed) {
+                    // The previous attempt is still `processing` with no recorded
+                    // exception: the job was released back onto the queue (rate
+                    // limiting, middleware, a manual release), not retried after a
+                    // failure. Update the same row in place so a release does not
+                    // leave a phantom `failed` row or a duplicate row per delivery.
+                    $this->repository->update($jobMonitor->uuid, [
+                        'status' => JobStatus::PROCESSING,
+                        'attempt' => $attempt,
+                        'started_at' => now(),
+                        'server_name' => $workerContext->serverName,
+                        'worker_id' => $workerContext->workerId,
+                        'worker_type' => $workerContext->workerType->value,
+                    ]);
+
+                    return;
+                }
+
+                // Genuine retry after a failure. Mark the prior attempt FAILED if it
+                // isn't already terminal (Laravel doesn't fire JobFailed for
+                // intermediate retries), then preserve the attempts trail below.
                 if (! $jobMonitor->status->isFinished()) {
                     $this->repository->update($jobMonitor->uuid, [
                         'status' => JobStatus::FAILED,

--- a/tests/Feature/Actions/DatabaseDriverJobIdTest.php
+++ b/tests/Feature/Actions/DatabaseDriverJobIdTest.php
@@ -49,6 +49,7 @@ test('database driver integer job id records completion without error', function
 
     $mockJob = Mockery::mock(Job::class);
     $mockJob->shouldReceive('getJobId')->andReturn(12345);
+    $mockJob->shouldReceive('isReleased')->andReturn(false);
 
     app(RecordJobCompletedAction::class)->execute(new JobProcessed('database', $mockJob));
 

--- a/tests/Feature/Actions/RecordJobStartedRetryTest.php
+++ b/tests/Feature/Actions/RecordJobStartedRetryTest.php
@@ -9,10 +9,14 @@ use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobProcessing;
 
 test('retry creates new record linked to previous attempt', function () {
+    // A genuine retry is a redelivery whose prior attempt actually failed; the
+    // exception listener records exception_class on that attempt, which is how
+    // the started action tells a real retry from a plain release.
     $original = JobMonitor::factory()->processing()->create([
         'job_id' => 'retry-job-1',
         'attempt' => 1,
         'started_at' => now()->subSeconds(5),
+        'exception_class' => 'RuntimeException',
     ]);
 
     $mockJob = Mockery::mock(Job::class);
@@ -34,6 +38,32 @@ test('retry creates new record linked to previous attempt', function () {
     expect($retry->status)->toBe(JobStatus::PROCESSING);
     expect($retry->retried_from_id)->toBe($original->id);
     expect($retry->job_id)->toBe('retry-job-1');
+});
+
+test('released job redelivery reuses the row without a failed duplicate', function () {
+    // Prior attempt still processing with no recorded exception = a release
+    // (rate limit / middleware / manual), not a failure.
+    $original = JobMonitor::factory()->processing()->create([
+        'job_id' => 'released-job-1',
+        'attempt' => 1,
+        'started_at' => now()->subSeconds(5),
+        'exception_class' => null,
+    ]);
+
+    $mockJob = Mockery::mock(Job::class);
+    $mockJob->shouldReceive('getJobId')->andReturn('released-job-1');
+    $mockJob->shouldReceive('attempts')->andReturn(2);
+    $mockJob->shouldReceive('payload')->andReturn([]);
+
+    app(RecordJobStartedAction::class)->execute(new JobProcessing('redis', $mockJob));
+
+    // No failed flip and no duplicate row — the same attempt row is reused.
+    expect(JobMonitor::count())->toBe(1);
+
+    $original->refresh();
+    expect($original->status)->toBe(JobStatus::PROCESSING);
+    expect($original->attempt)->toBe(2);
+    expect($original->completed_at)->toBeNull();
 });
 
 test('createFromProcessing when no existing record for job', function () {

--- a/tests/Feature/Listeners/DirectListenerTest.php
+++ b/tests/Feature/Listeners/DirectListenerTest.php
@@ -49,6 +49,7 @@ test('JobProcessedListener marks job completed', function () {
 
     $mockJob = Mockery::mock(Job::class);
     $mockJob->shouldReceive('getJobId')->andReturn('done-1');
+    $mockJob->shouldReceive('isReleased')->andReturn(false);
 
     $listener = new JobProcessedListener;
     $listener->handle(new JobProcessed('redis', $mockJob));

--- a/tests/Feature/Listeners/JobLifecycleTest.php
+++ b/tests/Feature/Listeners/JobLifecycleTest.php
@@ -103,6 +103,7 @@ test('job processed event marks completion', function () {
 
     $mockJob = Mockery::mock(Job::class);
     $mockJob->shouldReceive('getJobId')->andReturn('12345');
+    $mockJob->shouldReceive('isReleased')->andReturn(false);
 
     // Directly invoke the action to avoid silent failures in listener try/catch
     $event = new JobProcessed('redis', $mockJob);
@@ -113,6 +114,23 @@ test('job processed event marks completion', function () {
     expect($monitor->status)->toBe(JobStatus::COMPLETED);
     expect($monitor->completed_at)->not->toBeNull();
     expect($monitor->duration_ms)->toBeGreaterThan(0);
+});
+
+test('job processed event does not complete a released job', function () {
+    $monitor = JobMonitor::factory()->processing()->create([
+        'job_id' => 'released-1',
+        'started_at' => now()->subSeconds(5),
+    ]);
+
+    $mockJob = Mockery::mock(Job::class);
+    $mockJob->shouldReceive('getJobId')->andReturn('released-1');
+    $mockJob->shouldReceive('isReleased')->andReturn(true);
+
+    app(RecordJobCompletedAction::class)->execute(new JobProcessed('redis', $mockJob));
+
+    $monitor->refresh();
+    expect($monitor->status)->toBe(JobStatus::PROCESSING);
+    expect($monitor->completed_at)->toBeNull();
 });
 
 test('job failed event captures exception', function () {
@@ -150,6 +168,7 @@ test('complete job lifecycle is tracked', function () {
     $mockJob->shouldReceive('getJobId')->andReturn('12345');
     $mockJob->shouldReceive('attempts')->andReturn(1);
     $mockJob->shouldReceive('payload')->andReturn([]);
+    $mockJob->shouldReceive('isReleased')->andReturn(false);
 
     // Directly invoke actions to avoid silent failures in listener try/catch
     $processingEvent = new JobProcessing('redis', $mockJob);


### PR DESCRIPTION
## What

A job that releases itself back onto the queue (rate-limit / funnel middleware, circuit breakers, a manual `release()`) is no longer recorded as `completed`, and its redelivery no longer produces an extra monitor row.

## Why

Laravel fires `JobProcessed` after `fire()` **regardless of whether the job released itself**. `RecordJobCompletedAction` handled that event without checking `$event->job->isReleased()`, so a released (still in-flight) attempt was marked `completed`. On the next delivery, `RecordJobStartedAction` saw `attempts() > 1` on a non-finished prior row and created a fresh attempt row. So a job released N times produced **N+1 rows, the first N wrongly counted as completions** — inflating completion metrics and bloating `queue_monitor_jobs` under release-heavy workloads.

(The `isFinished()` guard already prevents the prior row being flipped to `failed` in this exact path, so the symptom today is inflated completions + row growth rather than spurious failures — but the root cause, `RecordJobCompletedAction` ignoring `isReleased()`, is the same.)

## How

- **`RecordJobCompletedAction`** returns early when `$event->job->isReleased()` — a release is not a completion, so the attempt row is left for the redelivery to update in place.
- **`RecordJobStartedAction`** now distinguishes, on `attempts() > 1`, a *genuine retry* from a *release*:
  - **Genuine retry** — the prior attempt actually failed, so it carries a recorded `exception_class` (stamped by `JobExceptionOccurredListener`) or is already finished. Behavior is unchanged: mark the prior attempt `failed` if it isn't terminal, then create a new attempt row (the per-attempt trail is preserved).
  - **Release** — the prior attempt is still `processing` with no recorded exception. Update the **same** row in place (bump `attempt`, refresh `started_at`/worker) instead of flipping it to `failed` or creating a duplicate.
- No new `JobStatus` and **no migration** — the `status` column is a DB `enum(JobStatus::values())`, so adding a state would mean a cross-database enum alteration; the exception-presence signal avoids that entirely.

## Testing

- New: a released job's `JobProcessed` leaves the row `processing` (not `completed`).
- New: a released redelivery reuses the same row (no `failed` flip, no duplicate).
- Updated the existing retry test so its prior attempt carries an exception, i.e. it now represents a genuine retry (still `failed` + new linked row).
- Full suite green, `composer analyse` and `pint` clean.

## Checklist

- [x] Code formatted with Pint
- [x] PHPStan passes
- [x] Tests added / updated
- [ ] Documentation updated (no user-facing surface changed; happy to note it if you'd like)
