### PR TITLE
[Fix] Record the queue a job was actually pushed to for batched jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
+## Unreleased
+
+### Fixes
+
+- **Batched jobs are recorded under the queue they were actually pushed to, not `default`.** `RecordJobQueuedAction` read the queue from the job *instance*. For jobs dispatched inside a `Bus::batch(...)->onQueue(...)`, Laravel applies the queue at the bulk-push level, so the instance's `$queue` stays `null` and every batched job was recorded/displayed under the literal `default`. The `JobQueued` event already carries the real destination in `$event->queue`; it is now preferred, falling back to the instance and then to the connection's configured default queue name. (Mirrors the fix `cboxdk/laravel-queue-metrics` shipped for its `JobQueuedListener` in v3.3.0.)
+
 ## v1.10.2 — Overview declutter - 2026-08-27
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to `laravel-queue-monitor` will be documented in this file.
 
-## Unreleased
-
-### Fixes
-
-- **Batched jobs are recorded under the queue they were actually pushed to, not `default`.** `RecordJobQueuedAction` read the queue from the job *instance*. For jobs dispatched inside a `Bus::batch(...)->onQueue(...)`, Laravel applies the queue at the bulk-push level, so the instance's `$queue` stays `null` and every batched job was recorded/displayed under the literal `default`. The `JobQueued` event already carries the real destination in `$event->queue`; it is now preferred, falling back to the instance and then to the connection's configured default queue name. (Mirrors the fix `cboxdk/laravel-queue-metrics` shipped for its `JobQueuedListener` in v3.3.0.)
-
 ## v1.10.2 — Overview declutter - 2026-08-27
 
 ### Fixes

--- a/src/Actions/Core/RecordJobQueuedAction.php
+++ b/src/Actions/Core/RecordJobQueuedAction.php
@@ -61,7 +61,7 @@ final readonly class RecordJobQueuedAction
             jobClass: $this->getJobClass($jobInstance),
             displayName: $this->getDisplayName($jobInstance),
             connection: $connectionName,
-            queue: $this->getQueue($jobInstance),
+            queue: $this->getQueue($event, $jobInstance, $connectionName),
             payload: $payload,
             status: JobStatus::QUEUED,
             attempt: 1,
@@ -162,19 +162,33 @@ final readonly class RecordJobQueuedAction
     }
 
     /**
-     * Get queue name from job
+     * Get queue name for the job.
+     *
+     * Prefer the queue carried by the JobQueued event: for jobs dispatched inside
+     * a Bus::batch(...)->onQueue(...), the queue is applied at the bulk-push level
+     * and the job instance's $queue property stays null, so reading it alone
+     * mis-records every batched job as `default`. Fall back to the instance, then
+     * to the connection's configured default queue name.
      */
-    private function getQueue(object $jobInstance): string
+    private function getQueue(object $event, object $jobInstance, string $connectionName): string
     {
+        $eventQueue = $event->queue ?? null;
+
+        if (is_string($eventQueue) && $eventQueue !== '') {
+            return $eventQueue;
+        }
+
         if ($jobInstance instanceof QueueJob) {
             return $jobInstance->getQueue();
         }
 
-        if (property_exists($jobInstance, 'queue')) {
-            return $jobInstance->queue ?? 'default';
+        if (property_exists($jobInstance, 'queue') && $jobInstance->queue !== null) {
+            return $jobInstance->queue;
         }
 
-        return 'default';
+        $configuredDefault = config("queue.connections.{$connectionName}.queue", 'default');
+
+        return is_string($configuredDefault) ? $configuredDefault : 'default';
     }
 
     /**

--- a/tests/Feature/Actions/RecordJobQueuedQueueNameTest.php
+++ b/tests/Feature/Actions/RecordJobQueuedQueueNameTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Cbox\LaravelQueueMonitor\Actions\Core\RecordJobQueuedAction;
+use Cbox\LaravelQueueMonitor\Models\JobMonitor;
+use Cbox\LaravelQueueMonitor\Tests\Support\ExampleJob;
+use Illuminate\Queue\Events\JobQueued;
+
+test('records the queue from the JobQueued event for a batched job', function () {
+    // Jobs dispatched inside Bus::batch(...)->onQueue(...) keep a null instance
+    // $queue; the real destination lives on the event.
+    $job = new ExampleJob;
+    expect($job->queue)->toBeNull();
+
+    $event = new JobQueued('redis', 'reports', '12345', $job, '{}', null);
+    app(RecordJobQueuedAction::class)->execute($event);
+
+    expect(JobMonitor::first()?->queue)->toBe('reports');
+});
+
+test('prefers an explicit instance queue when the event carries none', function () {
+    $job = new ExampleJob;
+    $job->queue = 'emails';
+
+    $event = new JobQueued('redis', '', '12345', $job, '{}', null);
+    app(RecordJobQueuedAction::class)->execute($event);
+
+    expect(JobMonitor::first()?->queue)->toBe('emails');
+});
+
+test('falls back to the connection default queue when nothing carries a queue', function () {
+    config()->set('queue.connections.redis.queue', 'redis-default');
+
+    $job = new ExampleJob;
+
+    $event = new JobQueued('redis', '', '12345', $job, '{}', null);
+    app(RecordJobQueuedAction::class)->execute($event);
+
+    expect(JobMonitor::first()?->queue)->toBe('redis-default');
+});


### PR DESCRIPTION
## What

Jobs dispatched inside a `Bus::batch(...)->onQueue(...)` are now recorded (and shown) under the queue they were actually pushed to, instead of the literal `default`.

## Why

`RecordJobQueuedAction::getQueue()` read the queue from the job **instance** (`$jobInstance->queue`). When a job is dispatched inside a batch, `Bus::batch(...)->onQueue(...)` applies the queue at the **bulk-push** level, so the individual job instance's `$queue` property stays `null` and every batched job was recorded as `default` — misattributing the busiest job traffic in the dashboard to a queue nothing writes to. The `JobQueued` event already carries the real destination in `$event->queue`, which the action ignored.

## How

`getQueue()` now prefers `$event->queue`, then falls back to the instance (`QueueJob::getQueue()` / the `$queue` property), then to the connection's configured default queue name rather than the literal `default`:

```php
$queue = $event->queue
    ?? $instanceQueue           // QueueJob::getQueue() or $instance->queue
    ?? config("queue.connections.{$connectionName}.queue", 'default');
```

This mirrors the fix `cboxdk/laravel-queue-metrics` already shipped for its `JobQueuedListener` in v3.3.0. Recording-only — it cannot change where jobs actually run.

## Testing

- New: a batched-style `JobQueued` (event queue set, instance `$queue` null) is recorded under the event's queue.
- New: an explicit instance `$queue` is honored when the event carries none.
- New: a fully implicit dispatch falls back to the connection's configured default queue name.
- Full suite green, `composer analyse` and `pint` clean.

## Checklist

- [x] Code formatted with Pint
- [x] PHPStan passes
- [x] Tests added
- [ ] Documentation updated (no user-facing config/API change)
